### PR TITLE
feat: add WebSocket binary server

### DIFF
--- a/src/CtfDeck.Terminal/Program.cs
+++ b/src/CtfDeck.Terminal/Program.cs
@@ -1,4 +1,56 @@
-﻿using CtfDeck.Terminal.Terminal;
+﻿using CtfDeck.Terminal.WebSocket;
 
-var service = new TerminalService();
-await service.RunAsync();
+var server = new WebSocketServer("localhost", 42712);
+
+var cts = new CancellationTokenSource();
+bool isShuttingDown = false;
+
+Console.CancelKeyPress += (sender, e) =>
+{
+    if (!isShuttingDown)
+    {
+        isShuttingDown = true;
+        e.Cancel = true;
+        Console.WriteLine("\nShutdown signal received. Stopping server...");
+        cts.Cancel();
+    }
+    else
+    {
+        e.Cancel = false;
+    }
+};
+
+try
+{
+    await server.StartAsync();
+
+    Console.WriteLine("Press Ctrl+C to stop the server...");
+
+    try
+    {
+        while (!cts.Token.IsCancellationRequested)
+        {
+            await Task.Delay(1000, cts.Token);
+        }
+    }
+    catch (TaskCanceledException)
+    {
+        Console.WriteLine("Server shutdown initiated...");
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Server error: {ex.Message}");
+}
+finally
+{
+    try
+    {
+        await server.StopAsync();
+        Console.WriteLine("Server stopped successfully.");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Error stopping server: {ex.Message}");
+    }
+}

--- a/src/CtfDeck.Terminal/WebSocket/BinaryProtocol.cs
+++ b/src/CtfDeck.Terminal/WebSocket/BinaryProtocol.cs
@@ -1,0 +1,124 @@
+using System.Text;
+
+namespace CtfDeck.Terminal.WebSocket;
+
+public struct WebSocketCommand
+{
+    public int CommandLength;
+    public byte[] CommandBytes;
+    public Guid MessageId;
+
+    public string Command => Encoding.UTF8.GetString(CommandBytes);
+
+    public static WebSocketCommand FromCommand(string command, Guid messageId)
+    {
+        var commandBytes = Encoding.UTF8.GetBytes(command);
+        return new WebSocketCommand
+        {
+            CommandLength = commandBytes.Length,
+            CommandBytes = commandBytes,
+            MessageId = messageId
+        };
+    }
+
+    public byte[] Serialize()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(CommandLength);
+        writer.Write(CommandBytes);
+        writer.Write(MessageId.ToByteArray());
+
+        return stream.ToArray();
+    }
+
+    public static WebSocketCommand Deserialize(byte[] data)
+    {
+        using var stream = new MemoryStream(data);
+        using var reader = new BinaryReader(stream);
+
+        var commandLength = reader.ReadInt32();
+        var commandBytes = reader.ReadBytes(commandLength);
+        var messageIdBytes = reader.ReadBytes(16);
+
+        return new WebSocketCommand
+        {
+            CommandLength = commandLength,
+            CommandBytes = commandBytes,
+            MessageId = new Guid(messageIdBytes)
+        };
+    }
+}
+
+public struct WebSocketResponse
+{
+    public int ExitCode;
+    public int OutputLength;
+    public byte[] OutputBytes;
+    public int ErrorLength;
+    public byte[] ErrorBytes;
+    public Guid MessageId;
+
+    public string Output => Encoding.UTF8.GetString(OutputBytes);
+    public string Error => Encoding.UTF8.GetString(ErrorBytes);
+
+    public static WebSocketResponse FromResult(int exitCode, string output, string error, Guid messageId)
+    {
+        var outputBytes = Encoding.UTF8.GetBytes(output);
+        var errorBytes = Encoding.UTF8.GetBytes(error);
+
+        return new WebSocketResponse
+        {
+            ExitCode = exitCode,
+            OutputLength = outputBytes.Length,
+            OutputBytes = outputBytes,
+            ErrorLength = errorBytes.Length,
+            ErrorBytes = errorBytes,
+            MessageId = messageId
+        };
+    }
+
+    public static WebSocketResponse MockResponse(Guid messageId)
+    {
+        return FromResult(0, "Mock response from WebSocket server", "", messageId);
+    }
+
+    public byte[] Serialize()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(ExitCode);
+        writer.Write(OutputLength);
+        writer.Write(OutputBytes);
+        writer.Write(ErrorLength);
+        writer.Write(ErrorBytes);
+        writer.Write(MessageId.ToByteArray());
+
+        return stream.ToArray();
+    }
+
+    public static WebSocketResponse Deserialize(byte[] data)
+    {
+        using var stream = new MemoryStream(data);
+        using var reader = new BinaryReader(stream);
+
+        var exitCode = reader.ReadInt32();
+        var outputLength = reader.ReadInt32();
+        var outputBytes = reader.ReadBytes(outputLength);
+        var errorLength = reader.ReadInt32();
+        var errorBytes = reader.ReadBytes(errorLength);
+        var messageIdBytes = reader.ReadBytes(16);
+
+        return new WebSocketResponse
+        {
+            ExitCode = exitCode,
+            OutputLength = outputLength,
+            OutputBytes = outputBytes,
+            ErrorLength = errorLength,
+            ErrorBytes = errorBytes,
+            MessageId = new Guid(messageIdBytes)
+        };
+    }
+}

--- a/src/CtfDeck.Terminal/WebSocket/BinaryWebSocketServer.cs
+++ b/src/CtfDeck.Terminal/WebSocket/BinaryWebSocketServer.cs
@@ -1,0 +1,290 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
+using WsClient = System.Net.WebSockets.WebSocket;
+
+namespace CtfDeck.Terminal.WebSocket;
+
+public class WebSocketServer
+{
+    private readonly HttpListener _httpListener;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private readonly ConcurrentDictionary<string, WsClient> _connectedClients;
+    private bool _isRunning;
+    private Task? _listenerTask;
+
+    public WebSocketServer(string host = "localhost", int port = 8080)
+    {
+        _httpListener = new HttpListener();
+        _httpListener.Prefixes.Add($"http://{host}:{port}/");
+        _cancellationTokenSource = new CancellationTokenSource();
+        _connectedClients = new ConcurrentDictionary<string, WsClient>();
+    }
+
+    public async Task StartAsync()
+    {
+        if (_isRunning)
+        {
+            Console.WriteLine("WebSocket server is already running.");
+            return;
+        }
+
+        try
+        {
+            _httpListener.Start();
+            _isRunning = true;
+            Console.WriteLine($"WebSocket server started on {_httpListener.Prefixes.First()}");
+
+            _listenerTask = ListenForConnectionsAsync(_cancellationTokenSource.Token);
+
+            await Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to start WebSocket server: {ex.Message}");
+            _isRunning = false;
+            throw;
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        if (!_isRunning)
+            return;
+
+        try
+        {
+            _cancellationTokenSource.Cancel();
+
+            _httpListener.Stop();
+            _isRunning = false;
+
+            if (_listenerTask != null)
+            {
+                try
+                {
+                    await Task.WhenAny(_listenerTask, Task.Delay(2000));
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Error waiting for listener task: {ex.Message}");
+                }
+            }
+
+            var closeTasks = new List<Task>();
+            foreach (var client in _connectedClients.Values)
+            {
+                if (client.State == WebSocketState.Open)
+                {
+                    closeTasks.Add(client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server shutting down", CancellationToken.None));
+                }
+            }
+
+            if (closeTasks.Count > 0)
+            {
+                try
+                {
+                    await Task.WhenAll(closeTasks);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Error closing client connections: {ex.Message}");
+                }
+            }
+
+            _connectedClients.Clear();
+            Console.WriteLine("WebSocket server stopped successfully.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error during server shutdown: {ex.Message}");
+        }
+    }
+
+    private async Task ListenForConnectionsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && _isRunning)
+            {
+                try
+                {
+                    var context = await _httpListener.GetContextAsync();
+
+                    if (context.Request.IsWebSocketRequest)
+                    {
+                        _ = Task.Run(() => HandleWebSocketConnectionAsync(context), cancellationToken);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                        context.Response.Close();
+                    }
+                }
+                catch (HttpListenerException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        Console.WriteLine($"Error accepting connection: {ex.Message}");
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (!(ex is OperationCanceledException))
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                Console.WriteLine($"Error in connection listener: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task HandleWebSocketConnectionAsync(HttpListenerContext context)
+    {
+        WebSocketContext? webSocketContext = null;
+        string clientId = Guid.NewGuid().ToString();
+
+        try
+        {
+            webSocketContext = await context.AcceptWebSocketAsync(subProtocol: null);
+            var webSocket = webSocketContext.WebSocket;
+
+            if (webSocket.State == WebSocketState.Open)
+            {
+                _connectedClients.TryAdd(clientId, webSocket);
+                Console.WriteLine($"Client {clientId} connected from {context.Request.RemoteEndPoint}");
+
+                await HandleClientMessagesAsync(webSocket, clientId);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error handling WebSocket connection for client {clientId}: {ex.Message}");
+        }
+        finally
+        {
+            _connectedClients.TryRemove(clientId, out _);
+
+            if (webSocketContext?.WebSocket.State == WebSocketState.Open)
+            {
+                try
+                {
+                    await webSocketContext.WebSocket.CloseAsync(
+                        WebSocketCloseStatus.NormalClosure,
+                        "Connection closed",
+                        CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error closing WebSocket for client {clientId}: {ex.Message}");
+                }
+            }
+
+            Console.WriteLine($"Client {clientId} disconnected");
+        }
+    }
+
+    private async Task HandleClientMessagesAsync(WsClient webSocket, string clientId)
+    {
+        var buffer = new byte[1024 * 4];
+
+        try
+        {
+            while (webSocket.State == WebSocketState.Open && !_cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationTokenSource.Token);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+                    break;
+                }
+
+                if (result.MessageType == WebSocketMessageType.Binary)
+                {
+                    await ProcessBinaryMessage(webSocket, buffer, result.Count, clientId);
+                }
+            }
+        }
+        catch (WebSocketException ex)
+        {
+            Console.WriteLine($"WebSocket error for client {clientId}: {ex.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error handling messages for client {clientId}: {ex.Message}");
+        }
+    }
+
+    private async Task ProcessBinaryMessage(WsClient webSocket, byte[] buffer, int messageLength, string clientId)
+    {
+        try
+        {
+            var messageData = new byte[messageLength];
+            Array.Copy(buffer, messageData, messageLength);
+
+            var command = WebSocketCommand.Deserialize(messageData);
+
+            Console.WriteLine($"Client {clientId} sent command: '{command.Command}' (ID: {command.MessageId})");
+
+            var response = WebSocketResponse.MockResponse(command.MessageId);
+
+            response = WebSocketResponse.FromResult(
+                0,
+                $"Mock: Received command '{command.Command}' with {command.CommandLength} bytes",
+                "",
+                command.MessageId
+            );
+
+            var responseData = response.Serialize();
+            await webSocket.SendAsync(
+                new ArraySegment<byte>(responseData),
+                WebSocketMessageType.Binary,
+                true,
+                CancellationToken.None);
+
+            Console.WriteLine($"Sent response to client {clientId} for command ID: {command.MessageId}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error processing binary message from client {clientId}: {ex.Message}");
+
+            try
+            {
+                var errorResponse = WebSocketResponse.FromResult(
+                    -1,
+                    "",
+                    $"Error processing command: {ex.Message}",
+                    Guid.NewGuid());
+
+                var errorData = errorResponse.Serialize();
+                await webSocket.SendAsync(
+                    new ArraySegment<byte>(errorData),
+                    WebSocketMessageType.Binary,
+                    true,
+                    CancellationToken.None);
+            }
+            catch (Exception sendEx)
+            {
+                Console.WriteLine($"Failed to send error response to client {clientId}: {sendEx.Message}");
+            }
+        }
+    }
+
+    public bool IsRunning => _isRunning;
+
+    public int ConnectedClientCount => _connectedClients.Count(kvp => kvp.Value.State == WebSocketState.Open);
+}

--- a/src/CtfDeck.Terminal/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.Terminal/WebSocket/WebSocketServer.cs
@@ -221,7 +221,7 @@ public class WebSocketServer
         }
         catch (OperationCanceledException)
         {
-            
+            // Expected when shutting down
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This pull request introduces a new WebSocket-based server architecture to the `CtfDeck.Terminal` project, replacing the previous terminal service approach. The main changes include implementing a binary protocol for communication, adding a robust WebSocket server with client management, and updating the program entry point to use the new server. These changes lay the groundwork for handling terminal commands and responses over WebSocket connections.

**WebSocket Server Implementation**

* Added a new `WebSocketServer` class in `WebSocket/BinaryWebSocketServer.cs` that handles HTTP listener setup, client connection management, message processing, and graceful shutdown. It supports multiple clients, processes binary messages, and sends structured responses.

* Introduced a binary protocol via `WebSocketCommand` and `WebSocketResponse` structs in `WebSocket/BinaryProtocol.cs` for serializing/deserializing command and response data between clients and the server, including mock response generation for testing.

**Program Entry Point Update**

* Replaced the old terminal service startup in `Program.cs` with initialization and lifecycle management for the new `WebSocketServer`, including Ctrl+C handling for graceful shutdown and error reporting.

These changes provide a scalable and structured foundation for terminal command processing over WebSocket, enabling future enhancements such as real command execution and advanced client-server interactions.