### PR TITLE
Init websocket

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,315 @@
+# CtfDeck WebSocket Binary Protocol
+
+## Overview
+
+The CtfDeck WebSocket Binary Protocol is a high-performance binary protocol designed for real-time command execution and response handling over WebSocket connections. It provides efficient serialization, message correlation, and error handling for terminal command execution.
+
+**Key Features:**
+- Binary message format for optimal performance
+- Message correlation using UUIDs
+- UTF-8 encoded command strings
+- Multi-client support
+- Cross-platform compatibility
+
+## Connection Handshake
+
+The protocol operates over standard WebSocket connections. Clients must perform a WebSocket upgrade handshake:
+
+```http
+GET / HTTP/1.1
+Host: localhost:42712
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==
+Sec-WebSocket-Protocol:
+Sec-WebSocket-Version: 13
+```
+
+## Message Format
+
+All messages are transmitted as binary WebSocket frames using little-endian byte ordering.
+
+### Command Message
+
+Clients send commands using the following binary structure:
+
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 4    | int32     | Command length (N)
+4      | N    | bytes[]   | Command string (UTF-8)
+4+N    | 16   | bytes[16] | Message ID (UUID)
+```
+
+**Total Size:** 4 + N + 16 bytes
+
+### Response Message
+
+Servers respond with the following binary structure:
+
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 4    | int32     | Exit code
+4      | 4    | int32     | Output length (M)
+8      | M    | bytes[]   | Output string (UTF-8)
+8+M    | 4    | int32     | Error length (K)
+8+M+K  | K    | bytes[]   | Error string (UTF-8)
+8+M+K+4|16   | bytes[16] | Message ID (UUID)
+```
+
+**Total Size:** 8 + M + K + 16 bytes
+
+## Message Types
+
+### Command Message
+
+Sent by clients to execute shell commands.
+
+**Fields:**
+- `command_length`: Length of the command string in bytes
+- `command_bytes`: UTF-8 encoded command string
+- `message_id`: UUID for request-response correlation
+
+### Response Message
+
+Sent by servers with command execution results.
+
+**Fields:**
+- `exit_code`: Process exit code (0 = success, non-zero = error)
+- `output_length`: Length of stdout output in bytes
+- `output_bytes`: UTF-8 encoded stdout output
+- `error_length`: Length of stderr output in bytes
+- `error_bytes`: UTF-8 encoded stderr output
+- `message_id`: UUID matching the original command
+
+## Error Codes
+
+| Code | Description |
+|------|-------------|
+| 0    | Success - command executed successfully |
+| 1    | Command failed - non-zero exit code |
+| -1   | Protocol error - malformed message |
+| 2    | Invalid command format |
+| 127  | Command not found |
+
+## Message Flow
+
+```
+Client                      Server
+  |                           |
+  |-- WebSocket Upgrade -->    |
+  |                           |
+  |-- Binary Command --------> |
+  |   (cmd_length, cmd, id)   |
+  |                           |
+  |<-- Binary Response -------|
+  |   (exit_code, out, err, id)|
+  |                           |
+  |-- Close Connection -----> |
+```
+
+## Implementation Example
+
+### C# (.NET)
+
+```csharp
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Buffers.Binary;
+
+public class CtfDeckClient : IDisposable
+{
+    private readonly ClientWebSocket _webSocket;
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<CommandResponse>> _pendingCommands;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+    public CtfDeckClient(string uri)
+    {
+        _webSocket = new ClientWebSocket();
+        _pendingCommands = new ConcurrentDictionary<string, TaskCompletionSource<CommandResponse>>();
+        _cancellationTokenSource = new CancellationTokenSource();
+
+        _ = Task.Run(MessageLoop, _cancellationTokenSource.Token);
+    }
+
+    public async Task ConnectAsync(string uri)
+    {
+        await _webSocket.ConnectAsync(new Uri(uri), CancellationToken.None);
+    }
+
+    public byte[] SerializeCommand(string command, Guid messageId)
+    {
+        var commandBytes = Encoding.UTF8.GetBytes(command);
+        var messageIdBytes = messageId.ToByteArray();
+
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(commandBytes.Length);
+        writer.Write(commandBytes);
+        writer.Write(messageIdBytes);
+
+        return stream.ToArray();
+    }
+
+    public CommandResponse DeserializeResponse(byte[] data)
+    {
+        using var stream = new MemoryStream(data);
+        using var reader = new BinaryReader(stream);
+
+        var exitCode = reader.ReadInt32();
+        var outputLength = reader.ReadInt32();
+        var outputBytes = reader.ReadBytes(outputLength);
+        var errorLength = reader.ReadInt32();
+        var errorBytes = reader.ReadBytes(errorLength);
+        var messageIdBytes = reader.ReadBytes(16);
+
+        return new CommandResponse
+        {
+            ExitCode = exitCode,
+            Output = Encoding.UTF8.GetString(outputBytes),
+            Error = Encoding.UTF8.GetString(errorBytes),
+            MessageId = new Guid(messageIdBytes)
+        };
+    }
+
+    public async Task<CommandResponse> ExecuteCommandAsync(string command)
+    {
+        var messageId = Guid.NewGuid();
+        var tcs = new TaskCompletionSource<CommandResponse>();
+        _pendingCommands[messageId.ToString()] = tcs;
+
+        var message = SerializeCommand(command, messageId);
+        await _webSocket.SendAsync(new ArraySegment<byte>(message),
+            WebSocketMessageType.Binary, true, CancellationToken.None);
+
+        return await tcs.Task;
+    }
+
+    private async Task MessageLoop()
+    {
+        var buffer = new byte[1024 * 4];
+
+        try
+        {
+            while (_webSocket.State == WebSocketState.Open)
+            {
+                var result = await _webSocket.ReceiveAsync(
+                    new ArraySegment<byte>(buffer), _cancellationTokenSource.Token);
+
+                if (result.MessageType == WebSocketMessageType.Binary)
+                {
+                    var response = DeserializeResponse(buffer[..result.Count]);
+
+                    if (_pendingCommands.TryRemove(response.MessageId.ToString(), out var tcs))
+                    {
+                        tcs.SetResult(response);
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when shutting down
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _webSocket?.Dispose();
+        _cancellationTokenSource?.Dispose();
+    }
+}
+
+public class CommandResponse
+{
+    public int ExitCode { get; set; }
+    public string Output { get; set; } = "";
+    public string Error { get; set; } = "";
+    public Guid MessageId { get; set; }
+}
+
+// Usage example
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        using var client = new CtfDeckClient("ws://localhost:42712");
+        await client.ConnectAsync("ws://localhost:42712");
+
+        try
+        {
+            var response = await client.ExecuteCommandAsync("ls -la");
+            Console.WriteLine($"Exit Code: {response.ExitCode}");
+            Console.WriteLine($"Output: {response.Output}");
+            if (!string.IsNullOrEmpty(response.Error))
+            {
+                Console.WriteLine($"Error: {response.Error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Command failed: {ex.Message}");
+        }
+    }
+}
+```
+
+## Security Considerations
+
+### Input Validation
+- Commands should be validated on the server side
+- Limit command length to prevent buffer overflow attacks
+- Sanitize input to prevent injection attacks
+
+### Connection Security
+- Implement authentication/authorization as needed
+- Consider rate limiting to prevent abuse
+- No need of websocket secure connection because its intended to be executed locally only.
+
+### Message Size Limits
+- Maximum command length: 1MB
+- Maximum output length: 10MB
+- Maximum error length: 1MB
+
+## Implementation Guidelines
+
+### Error Handling
+- Always validate message format before processing
+- Return appropriate error codes for different failure scenarios
+- Log protocol errors for debugging
+
+### Performance
+- Reuse buffers for serialization/deserialization
+- Implement connection pooling for high-load scenarios
+- Consider compression for large outputs
+
+### Compatibility
+- Protocol version 1.0
+- Backward compatibility considerations for future versions
+- Test with different WebSocket implementations
+
+## Debugging
+
+### WebSocket Tools
+- Chrome DevTools Network panel
+- WebSocket King browser extension
+- `wscat` command-line tool
+
+### Message Inspection
+```bash
+# Using wscat for debugging
+npm install -g wscat
+wscat -c "ws://localhost:42712"
+```
+
+### Common Issues
+- Check byte order (little-endian required)
+- Verify UTF-8 encoding
+- Ensure proper message boundaries
+- Validate UUID format

--- a/src/CtfDeck.Terminal/Program.cs
+++ b/src/CtfDeck.Terminal/Program.cs
@@ -1,4 +1,56 @@
-﻿using CtfDeck.Terminal.Terminal;
+﻿using CtfDeck.Terminal.WebSocket;
 
-var service = new TerminalService();
-await service.RunAsync();
+var server = new WebSocketServer("localhost", 42712);
+
+var cts = new CancellationTokenSource();
+bool isShuttingDown = false;
+
+Console.CancelKeyPress += (sender, e) =>
+{
+    if (!isShuttingDown)
+    {
+        isShuttingDown = true;
+        e.Cancel = true;
+        Console.WriteLine("\nShutdown signal received. Stopping server...");
+        cts.Cancel();
+    }
+    else
+    {
+        e.Cancel = false;
+    }
+};
+
+try
+{
+    await server.StartAsync();
+
+    Console.WriteLine("Press Ctrl+C to stop the server...");
+
+    try
+    {
+        while (!cts.Token.IsCancellationRequested)
+        {
+            await Task.Delay(1000, cts.Token);
+        }
+    }
+    catch (TaskCanceledException)
+    {
+        Console.WriteLine("Server shutdown initiated...");
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Server error: {ex.Message}");
+}
+finally
+{
+    try
+    {
+        await server.StopAsync();
+        Console.WriteLine("Server stopped successfully.");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Error stopping server: {ex.Message}");
+    }
+}

--- a/src/CtfDeck.Terminal/WebSocket/BinaryProtocol.cs
+++ b/src/CtfDeck.Terminal/WebSocket/BinaryProtocol.cs
@@ -1,0 +1,124 @@
+using System.Text;
+
+namespace CtfDeck.Terminal.WebSocket;
+
+public struct WebSocketCommand
+{
+    public int CommandLength;
+    public byte[] CommandBytes;
+    public Guid MessageId;
+
+    public string Command => Encoding.UTF8.GetString(CommandBytes);
+
+    public static WebSocketCommand FromCommand(string command, Guid messageId)
+    {
+        var commandBytes = Encoding.UTF8.GetBytes(command);
+        return new WebSocketCommand
+        {
+            CommandLength = commandBytes.Length,
+            CommandBytes = commandBytes,
+            MessageId = messageId
+        };
+    }
+
+    public byte[] Serialize()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(CommandLength);
+        writer.Write(CommandBytes);
+        writer.Write(MessageId.ToByteArray());
+
+        return stream.ToArray();
+    }
+
+    public static WebSocketCommand Deserialize(byte[] data)
+    {
+        using var stream = new MemoryStream(data);
+        using var reader = new BinaryReader(stream);
+
+        var commandLength = reader.ReadInt32();
+        var commandBytes = reader.ReadBytes(commandLength);
+        var messageIdBytes = reader.ReadBytes(16);
+
+        return new WebSocketCommand
+        {
+            CommandLength = commandLength,
+            CommandBytes = commandBytes,
+            MessageId = new Guid(messageIdBytes)
+        };
+    }
+}
+
+public struct WebSocketResponse
+{
+    public int ExitCode;
+    public int OutputLength;
+    public byte[] OutputBytes;
+    public int ErrorLength;
+    public byte[] ErrorBytes;
+    public Guid MessageId;
+
+    public string Output => Encoding.UTF8.GetString(OutputBytes);
+    public string Error => Encoding.UTF8.GetString(ErrorBytes);
+
+    public static WebSocketResponse FromResult(int exitCode, string output, string error, Guid messageId)
+    {
+        var outputBytes = Encoding.UTF8.GetBytes(output);
+        var errorBytes = Encoding.UTF8.GetBytes(error);
+
+        return new WebSocketResponse
+        {
+            ExitCode = exitCode,
+            OutputLength = outputBytes.Length,
+            OutputBytes = outputBytes,
+            ErrorLength = errorBytes.Length,
+            ErrorBytes = errorBytes,
+            MessageId = messageId
+        };
+    }
+
+    public static WebSocketResponse MockResponse(Guid messageId)
+    {
+        return FromResult(0, "Mock response from WebSocket server", "", messageId);
+    }
+
+    public byte[] Serialize()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(ExitCode);
+        writer.Write(OutputLength);
+        writer.Write(OutputBytes);
+        writer.Write(ErrorLength);
+        writer.Write(ErrorBytes);
+        writer.Write(MessageId.ToByteArray());
+
+        return stream.ToArray();
+    }
+
+    public static WebSocketResponse Deserialize(byte[] data)
+    {
+        using var stream = new MemoryStream(data);
+        using var reader = new BinaryReader(stream);
+
+        var exitCode = reader.ReadInt32();
+        var outputLength = reader.ReadInt32();
+        var outputBytes = reader.ReadBytes(outputLength);
+        var errorLength = reader.ReadInt32();
+        var errorBytes = reader.ReadBytes(errorLength);
+        var messageIdBytes = reader.ReadBytes(16);
+
+        return new WebSocketResponse
+        {
+            ExitCode = exitCode,
+            OutputLength = outputLength,
+            OutputBytes = outputBytes,
+            ErrorLength = errorLength,
+            ErrorBytes = errorBytes,
+            MessageId = new Guid(messageIdBytes)
+        };
+    }
+}

--- a/src/CtfDeck.Terminal/WebSocket/BinaryWebSocketServer.cs
+++ b/src/CtfDeck.Terminal/WebSocket/BinaryWebSocketServer.cs
@@ -1,0 +1,290 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
+using WsClient = System.Net.WebSockets.WebSocket;
+
+namespace CtfDeck.Terminal.WebSocket;
+
+public class WebSocketServer
+{
+    private readonly HttpListener _httpListener;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+    private readonly ConcurrentDictionary<string, WsClient> _connectedClients;
+    private bool _isRunning;
+    private Task? _listenerTask;
+
+    public WebSocketServer(string host = "localhost", int port = 8080)
+    {
+        _httpListener = new HttpListener();
+        _httpListener.Prefixes.Add($"http://{host}:{port}/");
+        _cancellationTokenSource = new CancellationTokenSource();
+        _connectedClients = new ConcurrentDictionary<string, WsClient>();
+    }
+
+    public async Task StartAsync()
+    {
+        if (_isRunning)
+        {
+            Console.WriteLine("WebSocket server is already running.");
+            return;
+        }
+
+        try
+        {
+            _httpListener.Start();
+            _isRunning = true;
+            Console.WriteLine($"WebSocket server started on {_httpListener.Prefixes.First()}");
+
+            _listenerTask = ListenForConnectionsAsync(_cancellationTokenSource.Token);
+
+            await Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to start WebSocket server: {ex.Message}");
+            _isRunning = false;
+            throw;
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        if (!_isRunning)
+            return;
+
+        try
+        {
+            _cancellationTokenSource.Cancel();
+
+            _httpListener.Stop();
+            _isRunning = false;
+
+            if (_listenerTask != null)
+            {
+                try
+                {
+                    await Task.WhenAny(_listenerTask, Task.Delay(2000));
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Error waiting for listener task: {ex.Message}");
+                }
+            }
+
+            var closeTasks = new List<Task>();
+            foreach (var client in _connectedClients.Values)
+            {
+                if (client.State == WebSocketState.Open)
+                {
+                    closeTasks.Add(client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server shutting down", CancellationToken.None));
+                }
+            }
+
+            if (closeTasks.Count > 0)
+            {
+                try
+                {
+                    await Task.WhenAll(closeTasks);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: Error closing client connections: {ex.Message}");
+                }
+            }
+
+            _connectedClients.Clear();
+            Console.WriteLine("WebSocket server stopped successfully.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error during server shutdown: {ex.Message}");
+        }
+    }
+
+    private async Task ListenForConnectionsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && _isRunning)
+            {
+                try
+                {
+                    var context = await _httpListener.GetContextAsync();
+
+                    if (context.Request.IsWebSocketRequest)
+                    {
+                        _ = Task.Run(() => HandleWebSocketConnectionAsync(context), cancellationToken);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                        context.Response.Close();
+                    }
+                }
+                catch (HttpListenerException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        Console.WriteLine($"Error accepting connection: {ex.Message}");
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (!(ex is OperationCanceledException))
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                Console.WriteLine($"Error in connection listener: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task HandleWebSocketConnectionAsync(HttpListenerContext context)
+    {
+        WebSocketContext? webSocketContext = null;
+        string clientId = Guid.NewGuid().ToString();
+
+        try
+        {
+            webSocketContext = await context.AcceptWebSocketAsync(subProtocol: null);
+            var webSocket = webSocketContext.WebSocket;
+
+            if (webSocket.State == WebSocketState.Open)
+            {
+                _connectedClients.TryAdd(clientId, webSocket);
+                Console.WriteLine($"Client {clientId} connected from {context.Request.RemoteEndPoint}");
+
+                await HandleClientMessagesAsync(webSocket, clientId);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error handling WebSocket connection for client {clientId}: {ex.Message}");
+        }
+        finally
+        {
+            _connectedClients.TryRemove(clientId, out _);
+
+            if (webSocketContext?.WebSocket.State == WebSocketState.Open)
+            {
+                try
+                {
+                    await webSocketContext.WebSocket.CloseAsync(
+                        WebSocketCloseStatus.NormalClosure,
+                        "Connection closed",
+                        CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error closing WebSocket for client {clientId}: {ex.Message}");
+                }
+            }
+
+            Console.WriteLine($"Client {clientId} disconnected");
+        }
+    }
+
+    private async Task HandleClientMessagesAsync(WsClient webSocket, string clientId)
+    {
+        var buffer = new byte[1024 * 4];
+
+        try
+        {
+            while (webSocket.State == WebSocketState.Open && !_cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationTokenSource.Token);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+                    break;
+                }
+
+                if (result.MessageType == WebSocketMessageType.Binary)
+                {
+                    await ProcessBinaryMessage(webSocket, buffer, result.Count, clientId);
+                }
+            }
+        }
+        catch (WebSocketException ex)
+        {
+            Console.WriteLine($"WebSocket error for client {clientId}: {ex.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error handling messages for client {clientId}: {ex.Message}");
+        }
+    }
+
+    private async Task ProcessBinaryMessage(WsClient webSocket, byte[] buffer, int messageLength, string clientId)
+    {
+        try
+        {
+            var messageData = new byte[messageLength];
+            Array.Copy(buffer, messageData, messageLength);
+
+            var command = WebSocketCommand.Deserialize(messageData);
+
+            Console.WriteLine($"Client {clientId} sent command: '{command.Command}' (ID: {command.MessageId})");
+
+            var response = WebSocketResponse.MockResponse(command.MessageId);
+
+            response = WebSocketResponse.FromResult(
+                0,
+                $"Mock: Received command '{command.Command}' with {command.CommandLength} bytes",
+                "",
+                command.MessageId
+            );
+
+            var responseData = response.Serialize();
+            await webSocket.SendAsync(
+                new ArraySegment<byte>(responseData),
+                WebSocketMessageType.Binary,
+                true,
+                CancellationToken.None);
+
+            Console.WriteLine($"Sent response to client {clientId} for command ID: {command.MessageId}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error processing binary message from client {clientId}: {ex.Message}");
+
+            try
+            {
+                var errorResponse = WebSocketResponse.FromResult(
+                    -1,
+                    "",
+                    $"Error processing command: {ex.Message}",
+                    Guid.NewGuid());
+
+                var errorData = errorResponse.Serialize();
+                await webSocket.SendAsync(
+                    new ArraySegment<byte>(errorData),
+                    WebSocketMessageType.Binary,
+                    true,
+                    CancellationToken.None);
+            }
+            catch (Exception sendEx)
+            {
+                Console.WriteLine($"Failed to send error response to client {clientId}: {sendEx.Message}");
+            }
+        }
+    }
+
+    public bool IsRunning => _isRunning;
+
+    public int ConnectedClientCount => _connectedClients.Count(kvp => kvp.Value.State == WebSocketState.Open);
+}

--- a/src/CtfDeck.Terminal/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.Terminal/WebSocket/WebSocketServer.cs
@@ -221,7 +221,7 @@ public class WebSocketServer
         }
         catch (OperationCanceledException)
         {
-            
+            // Expected when shutting down
         }
         catch (Exception ex)
         {

--- a/tests/CtfDeck.Tests/Terminal/TerminalServiceTests.cs
+++ b/tests/CtfDeck.Tests/Terminal/TerminalServiceTests.cs
@@ -1,10 +1,16 @@
 using Xunit;
 using CtfDeck.Terminal.Terminal;
+using System.Runtime.InteropServices;
 
 namespace CtfDeck.Tests.Terminal;
 
 public class TerminalServiceTests
 {
+    private static string GetExpectedPromptSymbol()
+    {
+        // Windows uses ">", Unix systems use "$" or "#"
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ">" : "$";
+    }
     [Fact]
     public async Task RunAsync_WithExitCommand_ShouldTerminate()
     {

--- a/tests/CtfDeck.Tests/WebSocket/BinaryProtocolTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/BinaryProtocolTests.cs
@@ -1,0 +1,279 @@
+using CtfDeck.Terminal.WebSocket;
+using FluentAssertions;
+
+namespace CtfDeck.Tests.WebSocket;
+
+public class BinaryProtocolTests
+{
+    [Fact]
+    public void WebSocketCommand_FromCommand_ShouldCreateCorrectCommand()
+    {
+        // Arrange
+        var commandText = "echo 'hello world'";
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var command = WebSocketCommand.FromCommand(commandText, messageId);
+
+        // Assert
+        command.CommandLength.Should().Be(commandText.Length);
+        command.CommandBytes.Should().NotBeNull();
+        command.MessageId.Should().Be(messageId);
+        command.Command.Should().Be(commandText);
+    }
+
+    [Fact]
+    public void WebSocketCommand_Serialize_ShouldProduceCorrectBinaryFormat()
+    {
+        // Arrange
+        var commandText = "test command";
+        var messageId = Guid.NewGuid();
+        var command = WebSocketCommand.FromCommand(commandText, messageId);
+
+        // Act
+        var binaryData = command.Serialize();
+
+        // Assert
+        binaryData.Should().NotBeNull();
+        binaryData.Length.Should().BeGreaterThan(0);
+
+        // Verify structure: [4 bytes length] + [command bytes] + [16 bytes UUID]
+        binaryData.Length.Should().Be(4 + commandText.Length + 16);
+    }
+
+    [Fact]
+    public void WebSocketCommand_Deserialize_ShouldRestoreOriginalCommand()
+    {
+        // Arrange
+        var originalCommand = "ls -la /home/user";
+        var originalMessageId = Guid.NewGuid();
+        var originalCommandStruct = WebSocketCommand.FromCommand(originalCommand, originalMessageId);
+        var binaryData = originalCommandStruct.Serialize();
+
+        // Act
+        var deserializedCommand = WebSocketCommand.Deserialize(binaryData);
+
+        // Assert
+        deserializedCommand.CommandLength.Should().Be(originalCommand.Length);
+        deserializedCommand.Command.Should().Be(originalCommand);
+        deserializedCommand.MessageId.Should().Be(originalMessageId);
+    }
+
+    [Fact]
+    public void WebSocketCommand_Deserialize_EmptyCommand_ShouldWork()
+    {
+        // Arrange
+        var emptyCommand = "";
+        var messageId = Guid.NewGuid();
+        var originalCommand = WebSocketCommand.FromCommand(emptyCommand, messageId);
+        var binaryData = originalCommand.Serialize();
+
+        // Act
+        var deserializedCommand = WebSocketCommand.Deserialize(binaryData);
+
+        // Assert
+        deserializedCommand.CommandLength.Should().Be(0);
+        deserializedCommand.Command.Should().Be(emptyCommand);
+        deserializedCommand.MessageId.Should().Be(messageId);
+    }
+
+    [Fact]
+    public void WebSocketCommand_RoundTrip_ShouldMaintainDataIntegrity()
+    {
+        // Arrange
+        var commands = new[]
+        {
+            "echo hello",
+            "ls -la /var/log",
+            "grep -r \"pattern\" /etc/",
+            "curl -X POST https://api.example.com/data",
+            "docker run --rm -it ubuntu:latest bash"
+        };
+
+        foreach (var commandText in commands)
+        {
+            var messageId = Guid.NewGuid();
+            var originalCommand = WebSocketCommand.FromCommand(commandText, messageId);
+
+            // Act
+            var binaryData = originalCommand.Serialize();
+            var deserializedCommand = WebSocketCommand.Deserialize(binaryData);
+
+            // Assert
+            deserializedCommand.Command.Should().Be(commandText);
+            deserializedCommand.MessageId.Should().Be(messageId);
+            deserializedCommand.CommandLength.Should().Be(commandText.Length);
+        }
+    }
+
+    [Fact]
+    public void WebSocketResponse_FromResult_ShouldCreateCorrectResponse()
+    {
+        // Arrange
+        var exitCode = 0;
+        var output = "file1.txt\nfile2.txt\n";
+        var error = "";
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var response = WebSocketResponse.FromResult(exitCode, output, error, messageId);
+
+        // Assert
+        response.ExitCode.Should().Be(exitCode);
+        response.OutputLength.Should().Be(output.Length);
+        response.ErrorLength.Should().Be(error.Length);
+        response.MessageId.Should().Be(messageId);
+        response.Output.Should().Be(output);
+        response.Error.Should().Be(error);
+    }
+
+    [Fact]
+    public void WebSocketResponse_MockResponse_ShouldCreateMockResponse()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var response = WebSocketResponse.MockResponse(messageId);
+
+        // Assert
+        response.ExitCode.Should().Be(0);
+        response.Output.Should().Contain("Mock response");
+        response.Error.Should().BeEmpty();
+        response.MessageId.Should().Be(messageId);
+        response.OutputLength.Should().Be(response.Output.Length);
+        response.ErrorLength.Should().Be(0);
+    }
+
+    [Fact]
+    public void WebSocketResponse_Serialize_ShouldProduceCorrectBinaryFormat()
+    {
+        // Arrange
+        var exitCode = 1;
+        var output = "some output";
+        var error = "some error message";
+        var messageId = Guid.NewGuid();
+        var response = WebSocketResponse.FromResult(exitCode, output, error, messageId);
+
+        // Act
+        var binaryData = response.Serialize();
+
+        // Assert
+        binaryData.Should().NotBeNull();
+        binaryData.Length.Should().BeGreaterThan(0);
+
+        // Verify structure: [4 bytes exitCode] + [4 bytes outputLength] + [output bytes] + [4 bytes errorLength] + [error bytes] + [16 bytes UUID]
+        binaryData.Length.Should().Be(4 + 4 + output.Length + 4 + error.Length + 16);
+    }
+
+    [Fact]
+    public void WebSocketResponse_Deserialize_ShouldRestoreOriginalResponse()
+    {
+        // Arrange
+        var originalExitCode = 127;
+        var originalOutput = "command not found";
+        var originalError = "bash: nonexistentcommand: command not found";
+        var originalMessageId = Guid.NewGuid();
+        var originalResponse = WebSocketResponse.FromResult(originalExitCode, originalOutput, originalError, originalMessageId);
+        var binaryData = originalResponse.Serialize();
+
+        // Act
+        var deserializedResponse = WebSocketResponse.Deserialize(binaryData);
+
+        // Assert
+        deserializedResponse.ExitCode.Should().Be(originalExitCode);
+        deserializedResponse.Output.Should().Be(originalOutput);
+        deserializedResponse.Error.Should().Be(originalError);
+        deserializedResponse.MessageId.Should().Be(originalMessageId);
+        deserializedResponse.OutputLength.Should().Be(originalOutput.Length);
+        deserializedResponse.ErrorLength.Should().Be(originalError.Length);
+    }
+
+    [Fact]
+    public void WebSocketResponse_Deserialize_EmptyOutputAndError_ShouldWork()
+    {
+        // Arrange
+        var exitCode = 0;
+        var emptyOutput = "";
+        var emptyError = "";
+        var messageId = Guid.NewGuid();
+        var originalResponse = WebSocketResponse.FromResult(exitCode, emptyOutput, emptyError, messageId);
+        var binaryData = originalResponse.Serialize();
+
+        // Act
+        var deserializedResponse = WebSocketResponse.Deserialize(binaryData);
+
+        // Assert
+        deserializedResponse.ExitCode.Should().Be(exitCode);
+        deserializedResponse.Output.Should().Be(emptyOutput);
+        deserializedResponse.Error.Should().Be(emptyError);
+        deserializedResponse.OutputLength.Should().Be(0);
+        deserializedResponse.ErrorLength.Should().Be(0);
+        deserializedResponse.MessageId.Should().Be(messageId);
+    }
+
+    [Fact]
+    public void WebSocketResponse_RoundTrip_ShouldMaintainDataIntegrity()
+    {
+        // Arrange
+        var testCases = new[]
+        {
+            (ExitCode: 0, Output: "Success", Error: "", MessageId: Guid.NewGuid()),
+            (ExitCode: 1, Output: "", Error: "Permission denied", MessageId: Guid.NewGuid()),
+            (ExitCode: 127, Output: "", Error: "Command not found", MessageId: Guid.NewGuid()),
+            (ExitCode: 2, Output: "Line 1\nLine 2\nLine 3", Error: "Warning message", MessageId: Guid.NewGuid())
+        };
+
+        foreach (var testCase in testCases)
+        {
+            var originalResponse = WebSocketResponse.FromResult(testCase.ExitCode, testCase.Output, testCase.Error, testCase.MessageId);
+
+            // Act
+            var binaryData = originalResponse.Serialize();
+            var deserializedResponse = WebSocketResponse.Deserialize(binaryData);
+
+            // Assert
+            deserializedResponse.ExitCode.Should().Be(testCase.ExitCode);
+            deserializedResponse.Output.Should().Be(testCase.Output);
+            deserializedResponse.Error.Should().Be(testCase.Error);
+            deserializedResponse.MessageId.Should().Be(testCase.MessageId);
+        }
+    }
+
+    [Fact]
+    public void WebSocketCommand_Serialize_WithUnicodeText_ShouldWork()
+    {
+        // Arrange
+        var unicodeCommand = "echo '🚀 Hello 世界 🌍'";
+        var messageId = Guid.NewGuid();
+        var command = WebSocketCommand.FromCommand(unicodeCommand, messageId);
+
+        // Act
+        var binaryData = command.Serialize();
+        var deserializedCommand = WebSocketCommand.Deserialize(binaryData);
+
+        // Assert
+        deserializedCommand.Command.Should().Be(unicodeCommand);
+        deserializedCommand.MessageId.Should().Be(messageId);
+    }
+
+    [Fact]
+    public void WebSocketResponse_Serialize_WithUnicodeText_ShouldWork()
+    {
+        // Arrange
+        var unicodeOutput = "Files: 📄📁📋\nDone! ✅";
+        var unicodeError = "Erreur: ⚠️ Accès refusé";
+        var messageId = Guid.NewGuid();
+        var response = WebSocketResponse.FromResult(1, unicodeOutput, unicodeError, messageId);
+
+        // Act
+        var binaryData = response.Serialize();
+        var deserializedResponse = WebSocketResponse.Deserialize(binaryData);
+
+        // Assert
+        deserializedResponse.Output.Should().Be(unicodeOutput);
+        deserializedResponse.Error.Should().Be(unicodeError);
+        deserializedResponse.MessageId.Should().Be(messageId);
+        deserializedResponse.ExitCode.Should().Be(1);
+    }
+}

--- a/tests/CtfDeck.Tests/WebSocket/WebSocketIntegrationTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/WebSocketIntegrationTests.cs
@@ -1,0 +1,393 @@
+using System.Net.WebSockets;
+using System.Text;
+using CtfDeck.Terminal.WebSocket;
+using FluentAssertions;
+
+namespace CtfDeck.Tests.WebSocket;
+
+public class WebSocketIntegrationTests : IDisposable
+{
+    private readonly WebSocketServer _server;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+    public WebSocketIntegrationTests()
+    {
+        _cancellationTokenSource = new CancellationTokenSource();
+        _server = new WebSocketServer("localhost", 8095); // Use different port for tests
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _server.StopAsync().GetAwaiter().GetResult();
+            _cancellationTokenSource.Dispose();
+        }
+        catch
+        {
+            // Ignore cleanup errors in tests
+        }
+    }
+
+    [Fact]
+    public async Task ClientConnection_ShouldConnectAndDisconnectSuccessfully()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        using var client = new ClientWebSocket();
+        var serverUri = new Uri("ws://localhost:8095/");
+
+        try
+        {
+            // Act
+            await client.ConnectAsync(serverUri, CancellationToken.None);
+
+            // Assert
+            client.State.Should().Be(WebSocketState.Open);
+            _server.IsRunning.Should().BeTrue();
+        }
+        finally
+        {
+            if (client.State == WebSocketState.Open)
+            {
+                await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ClientSendingBinaryMessage_ShouldReceiveBinaryResponse()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        using var client = new ClientWebSocket();
+        var serverUri = new Uri("ws://localhost:8095/");
+
+        try
+        {
+            await client.ConnectAsync(serverUri, CancellationToken.None);
+
+            // Create test command
+            var command = "echo hello world";
+            var messageId = Guid.NewGuid();
+            var commandStruct = WebSocketCommand.FromCommand(command, messageId);
+            var commandData = commandStruct.Serialize();
+
+            // Act
+            await client.SendAsync(
+                new ArraySegment<byte>(commandData),
+                WebSocketMessageType.Binary,
+                true,
+                CancellationToken.None);
+
+            var responseBuffer = new byte[1024 * 4];
+            var responseResult = await client.ReceiveAsync(
+                new ArraySegment<byte>(responseBuffer),
+                CancellationToken.None);
+
+            // Assert
+            responseResult.MessageType.Should().Be(WebSocketMessageType.Binary);
+            responseResult.EndOfMessage.Should().BeTrue();
+
+            var responseData = new byte[responseResult.Count];
+            Array.Copy(responseBuffer, responseData, responseResult.Count);
+
+            var response = WebSocketResponse.Deserialize(responseData);
+            response.MessageId.Should().Be(messageId);
+            response.ExitCode.Should().Be(0);
+            response.Output.Should().Contain("echo hello world");
+            response.Error.Should().BeEmpty();
+        }
+        finally
+        {
+            if (client.State == WebSocketState.Open)
+            {
+                await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task MultipleClients_ShouldConnectSimultaneously()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        var clients = new List<ClientWebSocket>();
+        var connectionTasks = new List<Task>();
+
+        try
+        {
+            // Act - Connect multiple clients
+            for (int i = 0; i < 3; i++)
+            {
+                var client = new ClientWebSocket();
+                clients.Add(client);
+
+                var task = client.ConnectAsync(new Uri("ws://localhost:8095/"), CancellationToken.None);
+                connectionTasks.Add(task);
+            }
+
+            await Task.WhenAll(connectionTasks);
+
+            // Assert
+            foreach (var client in clients)
+            {
+                client.State.Should().Be(WebSocketState.Open);
+            }
+
+            _server.IsRunning.Should().BeTrue();
+        }
+        finally
+        {
+            // Cleanup
+            var closeTasks = new List<Task>();
+            foreach (var client in clients)
+            {
+                if (client.State == WebSocketState.Open)
+                {
+                    closeTasks.Add(client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None));
+                }
+            }
+            await Task.WhenAll(closeTasks);
+        }
+    }
+
+    [Fact]
+    public async Task ClientSendingMultipleCommands_ShouldReceiveResponsesForAll()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        using var client = new ClientWebSocket();
+        var serverUri = new Uri("ws://localhost:8095/");
+
+        try
+        {
+            await client.ConnectAsync(serverUri, CancellationToken.None);
+
+            var commands = new[] { "ls", "pwd", "whoami" };
+            var responses = new List<WebSocketResponse>();
+
+            // Act
+            foreach (var command in commands)
+            {
+                var messageId = Guid.NewGuid();
+                var commandStruct = WebSocketCommand.FromCommand(command, messageId);
+                var commandData = commandStruct.Serialize();
+
+                await client.SendAsync(
+                    new ArraySegment<byte>(commandData),
+                    WebSocketMessageType.Binary,
+                    true,
+                    CancellationToken.None);
+
+                var responseBuffer = new byte[1024 * 4];
+                var responseResult = await client.ReceiveAsync(
+                    new ArraySegment<byte>(responseBuffer),
+                    CancellationToken.None);
+
+                var responseData = new byte[responseResult.Count];
+                Array.Copy(responseBuffer, responseData, responseResult.Count);
+
+                var response = WebSocketResponse.Deserialize(responseData);
+                responses.Add(response);
+            }
+
+            // Assert
+            responses.Count.Should().Be(commands.Length);
+            for (int i = 0; i < responses.Count; i++)
+            {
+                responses[i].ExitCode.Should().Be(0);
+                responses[i].Output.Should().Contain(commands[i]);
+                responses[i].Error.Should().BeEmpty();
+            }
+        }
+        finally
+        {
+            if (client.State == WebSocketState.Open)
+            {
+                await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ClientSendingTextMessage_ShouldBeIgnoredOrError()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        using var client = new ClientWebSocket();
+        var serverUri = new Uri("ws://localhost:8095/");
+
+        try
+        {
+            await client.ConnectAsync(serverUri, CancellationToken.None);
+
+            var textMessage = Encoding.UTF8.GetBytes("Hello world");
+
+            // Act
+            await client.SendAsync(
+                new ArraySegment<byte>(textMessage),
+                WebSocketMessageType.Text,
+                true,
+                CancellationToken.None);
+
+            // Wait a bit to ensure server processes (or ignores) the message
+            await Task.Delay(100);
+
+            // Assert - Server should still be running and connection should be open
+            client.State.Should().Be(WebSocketState.Open);
+            _server.IsRunning.Should().BeTrue();
+        }
+        finally
+        {
+            if (client.State == WebSocketState.Open)
+            {
+                await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ClientClosingConnection_ShouldUpdateServerClientCount()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        // Initial state
+        _server.ConnectedClientCount.Should().Be(0);
+
+        using var client = new ClientWebSocket();
+        var serverUri = new Uri("ws://localhost:8095/");
+
+        try
+        {
+            // Act - Connect
+            await client.ConnectAsync(serverUri, CancellationToken.None);
+
+            // Give server time to register the connection
+            await Task.Delay(100);
+
+            // Assert after connection
+            _server.ConnectedClientCount.Should().BeGreaterThan(0);
+        }
+        finally
+        {
+            // Act - Disconnect
+            if (client.State == WebSocketState.Open)
+            {
+                await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None);
+            }
+
+            // Give server time to process disconnection
+            await Task.Delay(100);
+
+            // Assert after disconnection
+            _server.ConnectedClientCount.Should().Be(0);
+        }
+    }
+
+    [Fact]
+    public async Task EmptyCommand_ShouldReturnValidResponse()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        using var client = new ClientWebSocket();
+        var serverUri = new Uri("ws://localhost:8095/");
+
+        try
+        {
+            await client.ConnectAsync(serverUri, CancellationToken.None);
+
+            // Create empty command
+            var emptyCommand = "";
+            var messageId = Guid.NewGuid();
+            var commandStruct = WebSocketCommand.FromCommand(emptyCommand, messageId);
+            var commandData = commandStruct.Serialize();
+
+            // Act
+            await client.SendAsync(
+                new ArraySegment<byte>(commandData),
+                WebSocketMessageType.Binary,
+                true,
+                CancellationToken.None);
+
+            var responseBuffer = new byte[1024 * 4];
+            var responseResult = await client.ReceiveAsync(
+                new ArraySegment<byte>(responseBuffer),
+                CancellationToken.None);
+
+            // Assert
+            responseResult.MessageType.Should().Be(WebSocketMessageType.Binary);
+
+            var responseData = new byte[responseResult.Count];
+            Array.Copy(responseBuffer, responseData, responseResult.Count);
+
+            var response = WebSocketResponse.Deserialize(responseData);
+            response.MessageId.Should().Be(messageId);
+            response.ExitCode.Should().Be(0);
+        }
+        finally
+        {
+            if (client.State == WebSocketState.Open)
+            {
+                await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task LargeCommand_ShouldProcessCorrectly()
+    {
+        // Arrange
+        await _server.StartAsync();
+
+        using var client = new ClientWebSocket();
+        var serverUri = new Uri("ws://localhost:8095/");
+
+        try
+        {
+            await client.ConnectAsync(serverUri, CancellationToken.None);
+
+            // Create large command (1KB)
+            var largeCommand = new string('a', 1024);
+            var messageId = Guid.NewGuid();
+            var commandStruct = WebSocketCommand.FromCommand(largeCommand, messageId);
+            var commandData = commandStruct.Serialize();
+
+            // Act
+            await client.SendAsync(
+                new ArraySegment<byte>(commandData),
+                WebSocketMessageType.Binary,
+                true,
+                CancellationToken.None);
+
+            var responseBuffer = new byte[1024 * 8]; // Larger buffer for response
+            var responseResult = await client.ReceiveAsync(
+                new ArraySegment<byte>(responseBuffer),
+                CancellationToken.None);
+
+            // Assert
+            responseResult.MessageType.Should().Be(WebSocketMessageType.Binary);
+
+            var responseData = new byte[responseResult.Count];
+            Array.Copy(responseBuffer, responseData, responseResult.Count);
+
+            var response = WebSocketResponse.Deserialize(responseData);
+            response.MessageId.Should().Be(messageId);
+            response.ExitCode.Should().Be(0);
+        }
+        finally
+        {
+            if (client.State == WebSocketState.Open)
+            {
+                await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Test complete", CancellationToken.None);
+            }
+        }
+    }
+}

--- a/tests/CtfDeck.Tests/WebSocket/WebSocketServerTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/WebSocketServerTests.cs
@@ -1,0 +1,304 @@
+using System.Net;
+using System.Net.WebSockets;
+using CtfDeck.Terminal.WebSocket;
+using FluentAssertions;
+
+namespace CtfDeck.Tests.WebSocket;
+
+public class WebSocketServerTests
+{
+    [Fact]
+    public void Constructor_ShouldInitializeCorrectly()
+    {
+        // Arrange & Act
+        var server = new WebSocketServer();
+
+        // Assert
+        server.IsRunning.Should().BeFalse();
+        server.ConnectedClientCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Constructor_WithCustomHostAndPort_ShouldInitializeCorrectly()
+    {
+        // Arrange & Act
+        var server = new WebSocketServer("127.0.0.1", 9999);
+
+        // Assert
+        server.IsRunning.Should().BeFalse();
+        server.ConnectedClientCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void IsRunning_ShouldReflectServerState()
+    {
+        // Arrange
+        var server = new WebSocketServer();
+
+        // Assert - Initial state
+        server.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ConnectedClientCount_ShouldReturnZeroInitially()
+    {
+        // Arrange
+        var server = new WebSocketServer();
+
+        // Act & Assert
+        server.ConnectedClientCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldStartSuccessfully()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8081); // Use different port to avoid conflicts
+
+        try
+        {
+            // Act
+            await server.StartAsync();
+
+            // Assert
+            server.IsRunning.Should().BeTrue();
+        }
+        finally
+        {
+            // Cleanup
+            try
+            {
+                await server.StopAsync();
+            }
+            catch
+            {
+                // Ignore cleanup errors for this test
+            }
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_ShouldStopCleanly()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8082);
+        await server.StartAsync();
+
+        // Act
+        await server.StopAsync();
+
+        // Assert
+        server.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenNotRunning_ShouldReturn()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8083);
+
+        // Act & Assert - Should not throw
+        await server.StopAsync();
+        server.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenAlreadyRunning_ShouldReturn()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8084);
+        await server.StartAsync();
+
+        try
+        {
+            // Act
+            await server.StartAsync();
+
+            // Assert
+            server.IsRunning.Should().BeTrue();
+        }
+        finally
+        {
+            // Cleanup
+            await server.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task StartStopCycle_ShouldMaintainCorrectState()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8085);
+
+        // Act & Assert
+        server.IsRunning.Should().BeFalse();
+
+        await server.StartAsync();
+        server.IsRunning.Should().BeTrue();
+
+        await server.StopAsync();
+        server.IsRunning.Should().BeFalse();
+
+        await server.StartAsync();
+        server.IsRunning.Should().BeTrue();
+
+        await server.StopAsync();
+        server.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MultipleStops_WhenNotRunning_ShouldNotThrow()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8086);
+
+        // Act & Assert
+        await server.StopAsync();
+        await server.StopAsync();
+        await server.StopAsync();
+
+        server.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StartStopWithDifferentPorts_ShouldWorkCorrectly()
+    {
+        // Arrange
+        var ports = new[] { 8087, 8088, 8089 };
+
+        foreach (var port in ports)
+        {
+            var server = new WebSocketServer("localhost", port);
+
+            try
+            {
+                // Act
+                await server.StartAsync();
+
+                // Assert
+                server.IsRunning.Should().BeTrue();
+
+                // Cleanup
+                await server.StopAsync();
+                server.IsRunning.Should().BeFalse();
+            }
+            catch (Exception ex) when (ex.Message.Contains("Only one usage of each socket address"))
+            {
+                // Skip if port is in use (rare in test environment)
+                Console.WriteLine($"Port {port} is in use, skipping test");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ServerProperties_AfterStartStop_ShouldMaintainConsistency()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8090);
+
+        try
+        {
+            // Initial state
+            server.IsRunning.Should().BeFalse();
+            server.ConnectedClientCount.Should().Be(0);
+
+            // After start
+            await server.StartAsync();
+            server.IsRunning.Should().BeTrue();
+            server.ConnectedClientCount.Should().Be(0); // No clients connected yet
+
+            // After stop
+            await server.StopAsync();
+            server.IsRunning.Should().BeFalse();
+            server.ConnectedClientCount.Should().Be(0);
+        }
+        finally
+        {
+            await server.StopAsync(); // Ensure cleanup
+        }
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("0.0.0.0")]
+    public void Constructor_WithDifferentHosts_ShouldInitializeCorrectly(string host)
+    {
+        // Arrange & Act
+        var server = new WebSocketServer(host, 8091);
+
+        // Assert
+        server.IsRunning.Should().BeFalse();
+        server.ConnectedClientCount.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(1024)]
+    [InlineData(8080)]
+    [InlineData(65535)]
+    public void Constructor_WithValidPorts_ShouldInitializeCorrectly(int port)
+    {
+        // Arrange & Act
+        var server = new WebSocketServer("localhost", port);
+
+        // Assert
+        server.IsRunning.Should().BeFalse();
+        server.ConnectedClientCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StartAsync_WithInvalidPort_ShouldThrowException()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 99999); // Invalid port
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpListenerException>(() => server.StartAsync());
+        server.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StartStopStressTest_ShouldMaintainStability()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8092);
+        const int iterations = 5;
+
+        try
+        {
+            for (int i = 0; i < iterations; i++)
+            {
+                // Act
+                await server.StartAsync();
+                server.IsRunning.Should().BeTrue();
+
+                await server.StopAsync();
+                server.IsRunning.Should().BeFalse();
+            }
+        }
+        finally
+        {
+            await server.StopAsync(); // Ensure cleanup
+        }
+    }
+
+    [Fact]
+    public async Task ConnectedClientCount_ShouldReturnCorrectCount()
+    {
+        // Arrange
+        var server = new WebSocketServer("localhost", 8093);
+        await server.StartAsync();
+
+        try
+        {
+            // Act & Assert
+            // Initially no clients
+            server.ConnectedClientCount.Should().Be(0);
+        }
+        finally
+        {
+            await server.StopAsync();
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new WebSocket server implementation for the terminal application, including a custom binary protocol for communication and comprehensive unit tests for protocol serialization and deserialization. The main entry point is updated to launch the WebSocket server and handle graceful shutdown. The changes are organized into three main areas: WebSocket server infrastructure, binary protocol definition, and testing.

**Key changes:**

**WebSocket server infrastructure:**

- Added a new `WebSocketServer` class that listens for incoming WebSocket connections, manages connected clients, and handles binary protocol messages. The server supports starting, stopping, and graceful shutdown, with robust error handling and logging. (`src/CtfDeck.Terminal/WebSocket/WebSocketServer.cs`)
- Updated the application entry point in `Program.cs` to instantiate and run the `WebSocketServer` instead of the previous `TerminalService`, including Ctrl+C handling for clean shutdown. (`src/CtfDeck.Terminal/Program.cs`)

**Binary protocol definition:**

- Introduced `WebSocketCommand` and `WebSocketResponse` structs to define the binary protocol for communication between clients and the server. These include methods for serialization, deserialization, and helpers for constructing protocol messages. (`src/CtfDeck.Terminal/WebSocket/BinaryProtocol.cs`)

**Testing:**

- Added a comprehensive test suite for the binary protocol, covering serialization/deserialization, data integrity, Unicode handling, and edge cases for both commands and responses. (`tests/CtfDeck.Tests/WebSocket/BinaryProtocolTests.cs`)
- Improved platform compatibility in existing terminal tests by introducing a helper to determine the expected prompt symbol based on the operating system. (`tests/CtfDeck.Tests/Terminal/TerminalServiceTests.cs`)