### PR TITLE
backlog/fix-macos-colors

### DIFF
--- a/src/CtfDeck.Terminal/Terminal/Execution/CommandPreprocessor.cs
+++ b/src/CtfDeck.Terminal/Terminal/Execution/CommandPreprocessor.cs
@@ -9,7 +9,8 @@ public static class CommandPreprocessor
     /// Environment setup for color support in bash
     /// </summary>
     private const string BashColorEnv =
-        "export TERM=xterm-256color; export COLORTERM=truecolor; export CLICOLOR_FORCE=1; eval \"$(dircolors -b)\" 2>/dev/null || true;";
+        "export TERM=xterm-256color; export COLORTERM=truecolor; export CLICOLOR_FORCE=1; " +
+        "command -v dircolors >/dev/null 2>&1 && eval \"$(dircolors -b)\" 2>/dev/null || true;";
 
     /// <summary>
     /// Commands that should have color flags injected


### PR DESCRIPTION
This pull request updates the environment setup for color support in bash within the `CommandPreprocessor` class. The main change ensures that the `dircolors` command is only evaluated if it is available on the system, improving compatibility and preventing potential errors.

**Environment setup improvements:**

* Modified the `BashColorEnv` constant in `CommandPreprocessor.cs` to check for the existence of the `dircolors` command before attempting to evaluate it, enhancing robustness across different environments.

(#52)