### PR TITLE
feature/reports backend

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -31,6 +31,26 @@ Collection storing reusable command templates (custom scripts).
 |-------|------|--------|
 | `_id` (Id) | GUID | Yes |
 
+### `writeups`
+
+Collection storing CTF write-ups (reports). Each write-up is linked to a session via `SessionId`.
+
+**Indexes:**
+| Field | Type | Unique |
+|-------|------|--------|
+| `_id` (Id) | GUID | Yes |
+| `SessionId` | GUID | No |
+
+### `media`
+
+Collection storing binary blobs (images, videos, PDFs, etc.) that can be referenced from write-up markdown content.
+
+**Indexes:**
+| Field | Type | Unique |
+|-------|------|--------|
+| `_id` (Id) | GUID | Yes |
+| `FileName` | String | No |
+
 ---
 
 ## Document Schemas
@@ -230,6 +250,77 @@ Stored as integer in database.
 }
 ```
 
+### WriteUp
+
+Root document representing a CTF write-up (report).
+
+```json
+{
+  "_id": "GUID",
+  "SessionId": "GUID",
+  "Name": "string",
+  "Content": "string (markdown)",
+  "CreatedAt": "DateTime (UTC)",
+  "UpdatedAt": "DateTime (UTC)"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_id` | `Guid` | Primary key, auto-generated |
+| `SessionId` | `Guid` | Foreign key to Session (mandatory) |
+| `Name` | `string` | Write-up title |
+| `Content` | `string` | Markdown body (default empty) |
+| `CreatedAt` | `DateTime` | Creation timestamp (UTC) |
+| `UpdatedAt` | `DateTime` | Last modification timestamp (UTC) |
+
+### WriteUp Example
+
+```json
+{
+  "_id": { "$guid": "d4e5f6a7-b8c9-0123-4567-89abcdef0123" },
+  "SessionId": { "$guid": "550e8400-e29b-41d4-a716-446655440000" },
+  "Name": "HTB Machine Writeup",
+  "Content": "# Enumeration\n\n## Nmap\n\n```\nnmap -sV 10.10.10.100\n```\n\nFound ports 22 and 80 open...",
+  "CreatedAt": { "$date": "2024-02-04T12:00:00Z" },
+  "UpdatedAt": { "$date": "2024-02-04T14:30:00Z" }
+}
+```
+
+### Media
+
+Root document representing a binary blob (image, video, PDF, etc.).
+
+```json
+{
+  "_id": "GUID",
+  "FileName": "string",
+  "MimeType": "string",
+  "Data": "byte[] (binary)",
+  "CreatedAt": "DateTime (UTC)"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_id` | `Guid` | Primary key, auto-generated |
+| `FileName` | `string` | Original file name |
+| `MimeType` | `string` | MIME type (e.g., `image/png`, `application/pdf`) |
+| `Data` | `byte[]` | Binary blob (max 8 MB) |
+| `CreatedAt` | `DateTime` | Upload timestamp (UTC) |
+
+### Media Example
+
+```json
+{
+  "_id": { "$guid": "f1e2d3c4-b5a6-9780-1234-567890abcdef" },
+  "FileName": "nmap-scan.png",
+  "MimeType": "image/png",
+  "Data": { "$binary": "iVBORw0KGgoAAAANSUhEUg..." },
+  "CreatedAt": { "$date": "2024-02-04T12:05:00Z" }
+}
+```
+
 ---
 
 ## Configuration
@@ -243,6 +334,8 @@ BsonMapper.Global.Entity<Session>().Id(x => x.Id);
 BsonMapper.Global.Entity<HistoryEntry>().Id(x => x.Id);
 BsonMapper.Global.Entity<SessionTarget>().Id(x => x.Id);
 BsonMapper.Global.Entity<CustomScript>().Id(x => x.Id);
+BsonMapper.Global.Entity<WriteUp>().Id(x => x.Id);
+BsonMapper.Global.Entity<Media>().Id(x => x.Id);
 ```
 
 ### Connection Strings
@@ -278,9 +371,19 @@ Frontend (Electron/Angular)
          │                              ▼
          │                    CustomScriptRepository
          │                              │
+         ├── WriteUp Commands ──► WriteUpService
+         │                              │
+         │                              ▼
+         │                      WriteUpRepository
+         │                              │
+         ├── Media Commands ───► MediaService
+         │                              │
+         │                              ▼
+         │                       MediaRepository
+         │                              │
          └──────────────────────────────┤
                                         ▼
-                                 SessionDbContext
+                                  CtfDeckDbContext
                                         │
                                         ▼
                                     LiteDB File
@@ -293,9 +396,12 @@ Frontend (Electron/Angular)
 | Constraint | Value |
 |------------|-------|
 | Max output per command | 10 KB |
+| Max media file size | 8 MB |
 | Session name | No limit (string) |
 | History entries per session | No limit |
 | Targets per session | No limit |
+| Write-ups per session | No limit |
+| Media entries | No limit (global) |
 | Database file size | LiteDB limit (~4GB) |
 
 ---
@@ -304,10 +410,16 @@ Frontend (Electron/Angular)
 
 | Purpose | Path |
 |---------|------|
-| Session Models | `src/CtfDeck.Terminal/Session/Models/` |
-| Script Models | `src/CtfDeck.Terminal/Script/Models/` |
-| DbContext | `src/CtfDeck.Terminal/Session/Data/SessionDbContext.cs` |
-| Session Repository | `src/CtfDeck.Terminal/Session/Repositories/SessionRepository.cs` |
-| Script Repository | `src/CtfDeck.Terminal/Script/Repositories/CustomScriptRepository.cs` |
-| Session Service | `src/CtfDeck.Terminal/Session/Services/SessionService.cs` |
-| Script Service | `src/CtfDeck.Terminal/Script/Services/CustomScriptService.cs` |
+| DbContext | `src/CtfDeck.Data/Db/CtfDeckDbContext.cs` |
+| Session Persistence Model | `src/CtfDeck.Data/PersistenceModels/Sessions/` |
+| Script Persistence Model | `src/CtfDeck.Data/PersistenceModels/Scripts/` |
+| WriteUp Persistence Model | `src/CtfDeck.Data/PersistenceModels/WriteUps/` |
+| Media Persistence Model | `src/CtfDeck.Data/PersistenceModels/Media/` |
+| Session Repository | `src/CtfDeck.Data/Repositories/Sessions/SessionRepository.cs` |
+| Script Repository | `src/CtfDeck.Data/Repositories/Scripts/CustomScriptRepository.cs` |
+| WriteUp Repository | `src/CtfDeck.Data/Repositories/WriteUps/WriteUpRepository.cs` |
+| Media Repository | `src/CtfDeck.Data/Repositories/Media/MediaRepository.cs` |
+| Session Service | `src/CtfDeck.Terminal/Features/Sessions/SessionService.cs` |
+| Script Service | `src/CtfDeck.Terminal/Features/Scripts/CustomScriptService.cs` |
+| WriteUp Service | `src/CtfDeck.Terminal/Features/WriteUps/WriteUpService.cs` |
+| Media Service | `src/CtfDeck.Terminal/Features/Media/MediaService.cs` |

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -15,24 +15,68 @@ This document provides an overview of the CTFDeck Backend repository structure, 
 
 The backend is currently consolidated into a main project:
 
-### [CtfDeck.Terminal](file:///home/binosspc/Documents/tek4/Capstone/CTFDeck/ctfdeck-back/src/CtfDeck.Terminal)
+### CtfDeck.ServerWs
 
-This is the core of the backend server. It implements the WebSocket host and coordinates command execution.
+Entry point and WebSocket server. Composition root that wires all dependencies manually (no DI container).
 
-- **`WebSocket/`**: Implementation of the binary WebSocket server and message dispatching.
-- **`Terminal/`**: Logic for interacting with the system shell (cmd, sh, bash) and streaming output.
-- **`Session/`**: Persistence layer using LiteDB to record command history and manage targets.
-- **`Script/`**: Management of custom scripts and command templates.
-- **`Dto/`**: Data Transfer Objects for binary serialization.
+- **`WebSocket/WebSocketServer.cs`**: HTTP→WS upgrade, per-client state, message routing, command dispatch.
+- **`WebSocket/OutputBatcher.cs`**: Channel-based batching (8KB/5ms) for streaming command output.
 - **`Program.cs`**: Entry point of the application.
+
+### CtfDeck.Terminal
+
+Business logic layer. Handles terminal execution, features, and message handlers.
+
+- **`Terminal/`**: Logic for interacting with the system shell (cmd, sh, bash) and streaming output.
+- **`Features/Sessions/`**: Session CRUD, active session tracking, command recording.
+- **`Features/Scripts/`**: Custom script CRUD wrapper.
+- **`Features/WriteUps/`**: Write-up CRUD service.
+- **`Features/Media/`**: Media CRUD service.
+- **`Handlers/`**: Message handler pipeline (`SessionMessageHandler`, `CustomScriptMessageHandler`, `WriteUpMessageHandler`, `MediaMessageHandler`).
+
+### CtfDeck.Contracts
+
+Binary protocol, DTOs, and protocol serializers/deserializers.
+
+- **`Transport/BinaryProtocol.cs`**: `MessageType` enum, wire structs, `PooledBufferWriter`.
+- **`Models/Sessions/`**: Session, HistoryEntry, SessionTarget DTOs.
+- **`Models/Scripts/`**: CustomScript DTOs.
+- **`Models/WriteUps/`**: WriteUp DTOs (`WriteUpDto`, `WriteUpMetadataDto`).
+- **`Models/Media/`**: Media DTOs (`MediaDto`, `MediaMetadataDto`).
+- **`Protocols/Session/`**: Session protocol serializer/deserializer.
+- **`Protocols/CustomScript/`**: Custom script protocol serializer/deserializer.
+- **`Protocols/WriteUp/`**: Write-up protocol serializer/deserializer.
+- **`Protocols/Media/`**: Media protocol serializer/deserializer.
+
+### CtfDeck.Abstractions
+
+Port interfaces (hexagonal architecture).
+
+- **`Ports/Sessions/ISessionRepository.cs`**
+- **`Ports/Scripts/ICustomScriptRepository.cs`**
+- **`Ports/WriteUps/IWriteUpRepository.cs`**
+- **`Ports/Media/IMediaRepository.cs`**
+
+### CtfDeck.Data
+
+LiteDB persistence layer (adapter).
+
+- **`Db/CtfDeckDbContext.cs`**: LiteDB setup. Collections: `sessions`, `customscripts`, `writeups`, `media`.
+- **`PersistenceModels/`**: Persistence models for Sessions, Scripts, WriteUps, Media.
+- **`Repositories/Sessions/`**: Implements `ISessionRepository`.
+- **`Repositories/Scripts/`**: Implements `ICustomScriptRepository`.
+- **`Repositories/WriteUps/`**: Implements `IWriteUpRepository`.
+- **`Repositories/Media/`**: Implements `IMediaRepository`.
 
 ---
 
 ## Tests (`tests/`)
 
-- **[CtfDeck.Tests](file:///home/binosspc/Documents/tek4/Capstone/CTFDeck/ctfdeck-back/tests/CtfDeck.Tests)**: Unit and integration tests for the Terminal project.
+- **CtfDeck.Tests**: Unit and integration tests.
   - **`Terminal/`**: Tests for shell interaction and command parsing.
-  - **`WebSocket/`**: Tests for the binary protocol and connection handling.
+  - **`WebSocket/`**: Tests for the binary protocol, connection handling, and integration.
+  - **`WriteUp/`**: Tests for write-up protocol serialization/deserialization round-trips.
+  - **`Media/`**: Tests for media protocol serialization/deserialization round-trips.
 
 ---
 
@@ -49,4 +93,4 @@ This is the core of the backend server. It implements the WebSocket host and coo
 ## Build and Output
 
 - **`bin/`** and **`obj/`**: Standard .NET build output directories (gitignored).
-- **`ctfdeck_sessions.db`**: LiteDB database file created at runtime to store session data.
+- **`ctfdeck.db`**: LiteDB database file created at runtime to store all data (sessions, scripts, write-ups, media).

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -104,6 +104,26 @@ All message types (1-byte prefix):
 | CustomScriptDeleteResult | 42 | Server → Client | Response to CustomScriptDelete |
 | CustomScriptListResult | 43 | Server → Client | Response to CustomScriptList |
 | CustomScriptOperationError | 49 | Server → Client | Custom script error response |
+| WriteUpCreate | 50 | Client → Server | Create a new write-up |
+| WriteUpUpdate | 51 | Client → Server | Update a write-up |
+| WriteUpDelete | 52 | Client → Server | Delete a write-up |
+| WriteUpList | 53 | Client → Server | List write-ups for a session |
+| WriteUpLoad | 54 | Client → Server | Load full write-up data |
+| WriteUpCreateResult | 60 | Server → Client | Response to WriteUpCreate |
+| WriteUpUpdateResult | 61 | Server → Client | Response to WriteUpUpdate |
+| WriteUpDeleteResult | 62 | Server → Client | Response to WriteUpDelete |
+| WriteUpListResult | 63 | Server → Client | Response to WriteUpList |
+| WriteUpLoadResult | 64 | Server → Client | Response to WriteUpLoad |
+| WriteUpOperationError | 69 | Server → Client | Write-up error response |
+| MediaUpload | 70 | Client → Server | Upload a media file |
+| MediaLoad | 71 | Client → Server | Load a media entry (with blob) |
+| MediaDelete | 72 | Client → Server | Delete a media entry |
+| MediaList | 73 | Client → Server | List all media (metadata only) |
+| MediaUploadResult | 80 | Server → Client | Response to MediaUpload |
+| MediaLoadResult | 81 | Server → Client | Response to MediaLoad |
+| MediaDeleteResult | 82 | Server → Client | Response to MediaDelete |
+| MediaListResult | 83 | Server → Client | Response to MediaList |
+| MediaOperationError | 89 | Server → Client | Media error response |
 
 ## Error Codes
 
@@ -888,4 +908,347 @@ Custom scripts are persisted using LiteDB:
 | Error | Cause | Resolution |
 |-------|-------|------------|
 | Script not found | Invalid script ID on update/delete | Use CustomScriptList to get valid IDs |
+| Database locked | Concurrent access | Retry operation |
+
+---
+
+## Write-Up Protocol
+
+### Overview
+
+The Write-Up Protocol extends the base protocol to support CTF write-ups (reports). Write-ups are linked to a session (mandatory `SessionId`), contain a name and markdown content, and support full CRUD operations. Write-ups are stored as separate documents (not embedded in sessions) to allow independent management.
+
+**Key Features:**
+- CRUD operations for write-ups
+- Session-scoped listing (by `SessionId`)
+- Markdown content storage
+- Separate metadata and full-content load paths
+- LiteDB persistence on server side
+
+### Message Types
+
+| Type | Value | Direction | Description |
+|------|-------|-----------|-------------|
+| WriteUpCreate | 50 | Client → Server | Create a new write-up |
+| WriteUpUpdate | 51 | Client → Server | Update name and content |
+| WriteUpDelete | 52 | Client → Server | Delete a write-up |
+| WriteUpList | 53 | Client → Server | List write-ups for a session (metadata) |
+| WriteUpLoad | 54 | Client → Server | Load full write-up data |
+| WriteUpCreateResult | 60 | Server → Client | Response to WriteUpCreate |
+| WriteUpUpdateResult | 61 | Server → Client | Response to WriteUpUpdate |
+| WriteUpDeleteResult | 62 | Server → Client | Response to WriteUpDelete |
+| WriteUpListResult | 63 | Server → Client | Response to WriteUpList |
+| WriteUpLoadResult | 64 | Server → Client | Response to WriteUpLoad |
+| WriteUpOperationError | 69 | Server → Client | Error response |
+
+### Request Message Formats
+
+#### WriteUpCreate
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (50)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Session ID (UUID)
+33     | 4    | int32     | Name length (N)
+37     | N    | bytes[]   | Write-up name (UTF-8)
+```
+
+#### WriteUpUpdate
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (51)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Write-up ID (UUID)
+33     | 4    | int32     | Name length (N)
+37     | N    | bytes[]   | Write-up name (UTF-8)
+37+N   | 4    | int32     | Content length (C)
+41+N   | C    | bytes[]   | Markdown content (UTF-8)
+```
+
+#### WriteUpDelete
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (52)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Write-up ID (UUID)
+```
+
+#### WriteUpList
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (53)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Session ID (UUID)
+```
+
+#### WriteUpLoad
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (54)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Write-up ID (UUID)
+```
+
+### Response Message Formats
+
+#### WriteUpCreateResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (60)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+18     | 16   | bytes[16] | Created write-up ID (UUID)
+```
+
+#### WriteUpUpdateResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (61)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### WriteUpDeleteResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (62)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### WriteUpListResult
+```
+OFFSET | SIZE | TYPE        | DESCRIPTION
+0      | 1    | byte        | Message type (63)
+1      | 16   | bytes[16]   | Message ID (UUID)
+17     | 4    | int32       | Write-up count (N)
+21     | ...  | Metadata[]  | Write-up metadata array
+```
+
+**WriteUpMetadata structure:**
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 16   | bytes[16] | Write-up ID (UUID)
+16     | 16   | bytes[16] | Session ID (UUID)
+32     | 4    | int32     | Name length (N)
+36     | N    | bytes[]   | Name (UTF-8)
+36+N   | 8    | int64     | CreatedAt (.NET ticks)
+44+N   | 8    | int64     | UpdatedAt (.NET ticks)
+```
+
+#### WriteUpLoadResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (64)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+18     | ...  | WriteUp   | Full write-up data (if success)
+```
+
+**WriteUp structure (when success = 1):**
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 16   | bytes[16] | Write-up ID (UUID)
+16     | 16   | bytes[16] | Session ID (UUID)
+32     | 4    | int32     | Name length (N)
+36     | N    | bytes[]   | Name (UTF-8)
+36+N   | 4    | int32     | Content length (C)
+40+N   | C    | bytes[]   | Markdown content (UTF-8)
+40+N+C | 8    | int64     | CreatedAt (.NET ticks)
+48+N+C | 8    | int64     | UpdatedAt (.NET ticks)
+```
+
+#### WriteUpOperationError
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (69)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 4    | int32     | Error length (E)
+21     | E    | bytes[]   | Error message (UTF-8)
+```
+
+### Storage
+
+Write-ups are persisted using LiteDB:
+- **Collection:** `writeups`
+- **Indexes:** `Id` (unique), `SessionId`
+
+### Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| Write-up not found | Invalid write-up ID on load/update/delete | Use WriteUpList to get valid IDs |
+| Session not found | Invalid session ID on create/list | Use SessionList to get valid session IDs |
+| Database locked | Concurrent access | Retry operation |
+
+---
+
+## Media Protocol
+
+### Overview
+
+The Media Protocol extends the base protocol to support binary blob storage (images, videos, PDFs, etc.). Media entries are stored globally (not tied to a session) and can be referenced from write-up markdown content by their ID. The server enforces an **8 MB per-file upload limit**.
+
+**Key Features:**
+- Upload, load, delete, and list operations
+- Binary blob storage with filename and MIME type metadata
+- 8 MB per-file upload limit (server-enforced)
+- Separate metadata listing (no blob) and full load (with blob) paths
+- Multi-frame WebSocket message support for large uploads
+- LiteDB persistence on server side
+
+### Message Types
+
+| Type | Value | Direction | Description |
+|------|-------|-----------|-------------|
+| MediaUpload | 70 | Client → Server | Upload a media file |
+| MediaLoad | 71 | Client → Server | Load a media entry (with blob) |
+| MediaDelete | 72 | Client → Server | Delete a media entry |
+| MediaList | 73 | Client → Server | List all media (metadata only) |
+| MediaUploadResult | 80 | Server → Client | Response to MediaUpload |
+| MediaLoadResult | 81 | Server → Client | Response to MediaLoad |
+| MediaDeleteResult | 82 | Server → Client | Response to MediaDelete |
+| MediaListResult | 83 | Server → Client | Response to MediaList |
+| MediaOperationError | 89 | Server → Client | Error response |
+
+### Request Message Formats
+
+#### MediaUpload
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (70)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 4    | int32     | File name length (F)
+21     | F    | bytes[]   | File name (UTF-8)
+21+F   | 4    | int32     | MIME type length (M)
+25+F   | M    | bytes[]   | MIME type (UTF-8)
+25+F+M | 4    | int32     | Data length (D)
+29+F+M | D    | bytes[]   | Binary data
+```
+
+**Notes:**
+- Maximum data length is 8 MB (8,388,608 bytes). The server rejects uploads exceeding this limit.
+- Large uploads may span multiple WebSocket frames. The server accumulates frames until `EndOfMessage` before processing.
+
+#### MediaLoad
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (71)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Media ID (UUID)
+```
+
+#### MediaDelete
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (72)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Media ID (UUID)
+```
+
+#### MediaList
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (73)
+1      | 16   | bytes[16] | Message ID (UUID)
+```
+
+### Response Message Formats
+
+#### MediaUploadResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (80)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+18     | 16   | bytes[16] | Created media ID (UUID)
+```
+
+#### MediaLoadResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (81)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+18     | ...  | Media     | Full media data (if success)
+```
+
+**Media structure (when success = 1):**
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 16   | bytes[16] | Media ID (UUID)
+16     | 4    | int32     | File name length (F)
+20     | F    | bytes[]   | File name (UTF-8)
+20+F   | 4    | int32     | MIME type length (M)
+24+F   | M    | bytes[]   | MIME type (UTF-8)
+24+F+M | 4    | int32     | Data length (D)
+28+F+M | D    | bytes[]   | Binary data
+```
+
+#### MediaDeleteResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (82)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### MediaListResult
+```
+OFFSET | SIZE | TYPE        | DESCRIPTION
+0      | 1    | byte        | Message type (83)
+1      | 16   | bytes[16]   | Message ID (UUID)
+17     | 4    | int32       | Media count (N)
+21     | ...  | Metadata[]  | Media metadata array
+```
+
+**MediaMetadata structure:**
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 16   | bytes[16] | Media ID (UUID)
+16     | 4    | int32     | File name length (F)
+20     | F    | bytes[]   | File name (UTF-8)
+20+F   | 4    | int32     | MIME type length (M)
+24+F   | M    | bytes[]   | MIME type (UTF-8)
+24+F+M | 8    | int64     | CreatedAt (.NET ticks)
+```
+
+#### MediaOperationError
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (89)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 4    | int32     | Error length (E)
+21     | E    | bytes[]   | Error message (UTF-8)
+```
+
+### Multi-Frame WebSocket Messages
+
+Media uploads can exceed the WebSocket receive buffer (64 KB). The server handles this transparently:
+
+1. **Single-frame messages** (vast majority): Zero-allocation — returns a slice of the shared receive buffer.
+2. **Multi-frame messages** (large uploads): Accumulates frames into a `MemoryStream` until `EndOfMessage`, then processes the complete payload.
+
+Clients do not need special handling — the WebSocket layer fragments large messages automatically.
+
+### Upload Limits
+
+| Constraint | Value |
+|------------|-------|
+| Max file size per upload | 8 MB (8,388,608 bytes) |
+| Validation | Server-side in `MediaMessageHandler` |
+| Error on exceed | `MediaOperationError` with descriptive message |
+
+### Storage
+
+Media entries are persisted using LiteDB:
+- **Collection:** `media`
+- **Indexes:** `Id` (unique), `FileName`
+
+### Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| File exceeds maximum upload size | Upload data > 8 MB | Reduce file size before uploading |
+| Media not found | Invalid media ID on load/delete | Use MediaList to get valid IDs |
 | Database locked | Concurrent access | Retry operation |

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -83,6 +83,17 @@ dotnet test --filter "FullyQualifiedName~MyTestClass.MyTestMethod"
 dotnet test --test-adapter-path:. --logger:trx
 ```
 
+## Test Structure
+
+The test suite covers all protocol layers and terminal functionality:
+
+| Directory | Files | Coverage |
+|-----------|-------|----------|
+| `Terminal/` | `CommandResultTests.cs`, `TerminalExecutorTests.cs`, `TerminalServiceTests.cs` | Shell interaction, cd navigation, REPL loop |
+| `WebSocket/` | `BinaryProtocolTests.cs`, `OutputBatcherTests.cs`, `WebSocketServerTests.cs`, `WebSocketIntegrationTests.cs` | Binary protocol round-trips, batching, server lifecycle, real WebSocket connections |
+| `WriteUp/` | `WriteUpProtocolTests.cs` | Write-up protocol serialize/deserialize round-trips, unicode content, message type range |
+| `Media/` | `MediaProtocolTests.cs` | Media protocol serialize/deserialize round-trips, large binary data, message type range |
+
 ## Continuous Integration
 
 The test suite is designed to run in CI/CD pipelines. The project includes GitHub Actions workflows (in `.github/workflows/`) that automatically run tests on push and pull requests.

--- a/src/CtfDeck.Abstractions/Ports/Media/IMediaRepository.cs
+++ b/src/CtfDeck.Abstractions/Ports/Media/IMediaRepository.cs
@@ -1,0 +1,11 @@
+using CtfDeck.Contracts.Models.Media;
+
+namespace CtfDeck.Abstractions.Ports.Media;
+
+public interface IMediaRepository
+{
+    MediaDto Create(string fileName, string mimeType, byte[] data);
+    MediaDto? GetById(Guid id);
+    List<MediaMetadataDto> GetAll();
+    bool Delete(Guid id);
+}

--- a/src/CtfDeck.Abstractions/Ports/WriteUps/IWriteUpRepository.cs
+++ b/src/CtfDeck.Abstractions/Ports/WriteUps/IWriteUpRepository.cs
@@ -1,0 +1,12 @@
+using CtfDeck.Contracts.Models.WriteUps;
+
+namespace CtfDeck.Abstractions.Ports.WriteUps;
+
+public interface IWriteUpRepository
+{
+    WriteUpDto Create(Guid sessionId, string name);
+    WriteUpDto? GetById(Guid id);
+    List<WriteUpMetadataDto> GetBySessionId(Guid sessionId);
+    bool Update(Guid id, string name, string content);
+    bool Delete(Guid id);
+}

--- a/src/CtfDeck.Contracts/Models/Media/MediaDto.cs
+++ b/src/CtfDeck.Contracts/Models/Media/MediaDto.cs
@@ -1,0 +1,10 @@
+namespace CtfDeck.Contracts.Models.Media;
+
+public sealed class MediaDto
+{
+    public Guid Id { get; set; }
+    public string FileName { get; set; } = "";
+    public string MimeType { get; set; } = "";
+    public byte[] Data { get; set; } = [];
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/CtfDeck.Contracts/Models/Media/MediaMetadataDto.cs
+++ b/src/CtfDeck.Contracts/Models/Media/MediaMetadataDto.cs
@@ -1,0 +1,9 @@
+namespace CtfDeck.Contracts.Models.Media;
+
+public sealed class MediaMetadataDto
+{
+    public Guid Id { get; set; }
+    public string FileName { get; set; } = "";
+    public string MimeType { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/CtfDeck.Contracts/Models/WriteUps/WriteUpDto.cs
+++ b/src/CtfDeck.Contracts/Models/WriteUps/WriteUpDto.cs
@@ -1,0 +1,11 @@
+namespace CtfDeck.Contracts.Models.WriteUps;
+
+public sealed class WriteUpDto
+{
+    public Guid Id { get; set; }
+    public Guid SessionId { get; set; }
+    public string Name { get; set; } = "";
+    public string Content { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/src/CtfDeck.Contracts/Models/WriteUps/WriteUpMetadataDto.cs
+++ b/src/CtfDeck.Contracts/Models/WriteUps/WriteUpMetadataDto.cs
@@ -1,0 +1,10 @@
+namespace CtfDeck.Contracts.Models.WriteUps;
+
+public sealed class WriteUpMetadataDto
+{
+    public Guid Id { get; set; }
+    public Guid SessionId { get; set; }
+    public string Name { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/src/CtfDeck.Contracts/Protocols/Media/MediaProtocolDeserializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/Media/MediaProtocolDeserializer.cs
@@ -1,0 +1,78 @@
+using System.Text;
+using CtfDeck.Contracts.Transport;
+
+namespace CtfDeck.Contracts.Protocols.Media;
+
+public readonly ref struct MediaUploadRequest
+{
+    public readonly Guid MessageId;
+    public readonly string FileName;
+    public readonly string MimeType;
+    public readonly ReadOnlySpan<byte> Data;
+
+    public MediaUploadRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][4B fileNameLen][fileName][4B mimeTypeLen][mimeType][4B dataLen][data]
+        MessageId = new Guid(data.Slice(1, 16));
+
+        var offset = 17;
+        var fileNameLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        FileName = Encoding.UTF8.GetString(data.Slice(offset, fileNameLen));
+        offset += fileNameLen;
+
+        var mimeTypeLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        MimeType = Encoding.UTF8.GetString(data.Slice(offset, mimeTypeLen));
+        offset += mimeTypeLen;
+
+        var dataLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Data = data.Slice(offset, dataLen);
+    }
+}
+
+public readonly ref struct MediaLoadRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid MediaId;
+
+    public MediaLoadRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B mediaId]
+        MessageId = new Guid(data.Slice(1, 16));
+        MediaId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public readonly ref struct MediaDeleteRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid MediaId;
+
+    public MediaDeleteRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B mediaId]
+        MessageId = new Guid(data.Slice(1, 16));
+        MediaId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public readonly ref struct MediaListRequest
+{
+    public readonly Guid MessageId;
+
+    public MediaListRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId]
+        MessageId = new Guid(data.Slice(1, 16));
+    }
+}
+
+public static class MediaProtocolDeserializer
+{
+    public static bool IsMediaMessage(MessageType type)
+    {
+        return type >= MessageType.MediaUpload && type <= MessageType.MediaList;
+    }
+}

--- a/src/CtfDeck.Contracts/Protocols/Media/MediaProtocolSerializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/Media/MediaProtocolSerializer.cs
@@ -1,0 +1,65 @@
+using CtfDeck.Contracts.Models.Media;
+using CtfDeck.Contracts.Transport;
+
+namespace CtfDeck.Contracts.Protocols.Media;
+
+public static class MediaProtocolSerializer
+{
+    public static byte[] SerializeUploadResult(Guid messageId, bool success, Guid mediaId)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaUploadResult);
+        writer.WriteGuid(messageId);
+        writer.WriteByte((byte)(success ? 1 : 0));
+        writer.WriteGuid(mediaId);
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeLoadResult(Guid messageId, bool success, MediaDto? media)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaLoadResult);
+        writer.WriteGuid(messageId);
+        writer.WriteByte((byte)(success ? 1 : 0));
+
+        if (success && media != null)
+        {
+            writer.WriteGuid(media.Id);
+            writer.WriteString(media.FileName);
+            writer.WriteString(media.MimeType);
+            writer.WriteInt32(media.Data.Length);
+            writer.WriteBytes(media.Data);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeDeleteResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.MediaDeleteResult, messageId, success);
+
+    public static byte[] SerializeListResult(Guid messageId, List<MediaMetadataDto> mediaList)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaListResult);
+        writer.WriteGuid(messageId);
+        writer.WriteInt32(mediaList.Count);
+
+        foreach (var media in mediaList)
+        {
+            WriteMediaMetadata(writer, media);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeError(Guid messageId, string error)
+        => BinaryProtocolSerializer.SerializeError(MessageType.MediaOperationError, messageId, error);
+
+    private static void WriteMediaMetadata(PooledBufferWriter writer, MediaMetadataDto media)
+    {
+        writer.WriteGuid(media.Id);
+        writer.WriteString(media.FileName);
+        writer.WriteString(media.MimeType);
+        writer.WriteInt64(media.CreatedAt.Ticks);
+    }
+}

--- a/src/CtfDeck.Contracts/Protocols/WriteUp/WriteUpProtocolDeserializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/WriteUp/WriteUpProtocolDeserializer.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using CtfDeck.Contracts.Transport;
+
+namespace CtfDeck.Contracts.Protocols.WriteUp;
+
+public readonly ref struct WriteUpCreateRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid SessionId;
+    public readonly string Name;
+
+    public WriteUpCreateRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B sessionId][4B nameLen][name]
+        MessageId = new Guid(data.Slice(1, 16));
+        SessionId = new Guid(data.Slice(17, 16));
+
+        var offset = 33;
+        var nameLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Name = Encoding.UTF8.GetString(data.Slice(offset, nameLen));
+    }
+}
+
+public readonly ref struct WriteUpUpdateRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid WriteUpId;
+    public readonly string Name;
+    public readonly string Content;
+
+    public WriteUpUpdateRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B writeUpId][4B nameLen][name][4B contentLen][content]
+        MessageId = new Guid(data.Slice(1, 16));
+        WriteUpId = new Guid(data.Slice(17, 16));
+
+        var offset = 33;
+        var nameLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Name = Encoding.UTF8.GetString(data.Slice(offset, nameLen));
+        offset += nameLen;
+
+        var contentLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Content = Encoding.UTF8.GetString(data.Slice(offset, contentLen));
+    }
+}
+
+public readonly ref struct WriteUpDeleteRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid WriteUpId;
+
+    public WriteUpDeleteRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B writeUpId]
+        MessageId = new Guid(data.Slice(1, 16));
+        WriteUpId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public readonly ref struct WriteUpListRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid SessionId;
+
+    public WriteUpListRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B sessionId]
+        MessageId = new Guid(data.Slice(1, 16));
+        SessionId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public readonly ref struct WriteUpLoadRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid WriteUpId;
+
+    public WriteUpLoadRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B writeUpId]
+        MessageId = new Guid(data.Slice(1, 16));
+        WriteUpId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public static class WriteUpProtocolDeserializer
+{
+    public static bool IsWriteUpMessage(MessageType type)
+    {
+        return type >= MessageType.WriteUpCreate && type <= MessageType.WriteUpLoad;
+    }
+}

--- a/src/CtfDeck.Contracts/Protocols/WriteUp/WriteUpProtocolSerializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/WriteUp/WriteUpProtocolSerializer.cs
@@ -1,0 +1,70 @@
+using CtfDeck.Contracts.Models.WriteUps;
+using CtfDeck.Contracts.Transport;
+
+namespace CtfDeck.Contracts.Protocols.WriteUp;
+
+public static class WriteUpProtocolSerializer
+{
+    public static byte[] SerializeCreateResult(Guid messageId, bool success, Guid writeUpId)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpCreateResult);
+        writer.WriteGuid(messageId);
+        writer.WriteByte((byte)(success ? 1 : 0));
+        writer.WriteGuid(writeUpId);
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeUpdateResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.WriteUpUpdateResult, messageId, success);
+
+    public static byte[] SerializeDeleteResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.WriteUpDeleteResult, messageId, success);
+
+    public static byte[] SerializeListResult(Guid messageId, List<WriteUpMetadataDto> writeUps)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpListResult);
+        writer.WriteGuid(messageId);
+        writer.WriteInt32(writeUps.Count);
+
+        foreach (var writeUp in writeUps)
+        {
+            WriteWriteUpMetadata(writer, writeUp);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeLoadResult(Guid messageId, bool success, WriteUpDto? writeUp)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpLoadResult);
+        writer.WriteGuid(messageId);
+        writer.WriteByte((byte)(success ? 1 : 0));
+
+        if (success && writeUp != null)
+        {
+            writer.WriteGuid(writeUp.Id);
+            writer.WriteGuid(writeUp.SessionId);
+            writer.WriteString(writeUp.Name);
+            writer.WriteString(writeUp.Content);
+            writer.WriteInt64(writeUp.CreatedAt.Ticks);
+            writer.WriteInt64(writeUp.UpdatedAt.Ticks);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeError(Guid messageId, string error)
+        => BinaryProtocolSerializer.SerializeError(MessageType.WriteUpOperationError, messageId, error);
+
+    private static void WriteWriteUpMetadata(PooledBufferWriter writer, WriteUpMetadataDto writeUp)
+    {
+        writer.WriteGuid(writeUp.Id);
+        writer.WriteGuid(writeUp.SessionId);
+        writer.WriteString(writeUp.Name);
+        writer.WriteInt64(writeUp.CreatedAt.Ticks);
+        writer.WriteInt64(writeUp.UpdatedAt.Ticks);
+    }
+}

--- a/src/CtfDeck.Contracts/Transport/BinaryProtocol.cs
+++ b/src/CtfDeck.Contracts/Transport/BinaryProtocol.cs
@@ -54,7 +54,35 @@ public enum MessageType : byte
     CustomScriptUpdateResult = 41,
     CustomScriptDeleteResult = 42,
     CustomScriptListResult = 43,
-    CustomScriptOperationError = 49
+    CustomScriptOperationError = 49,
+
+    // WriteUp requests (client → server)
+    WriteUpCreate = 50,
+    WriteUpUpdate = 51,
+    WriteUpDelete = 52,
+    WriteUpList = 53,
+    WriteUpLoad = 54,
+
+    // WriteUp responses (server → client)
+    WriteUpCreateResult = 60,
+    WriteUpUpdateResult = 61,
+    WriteUpDeleteResult = 62,
+    WriteUpListResult = 63,
+    WriteUpLoadResult = 64,
+    WriteUpOperationError = 69,
+
+    // Media requests (client → server)
+    MediaUpload = 70,
+    MediaLoad = 71,
+    MediaDelete = 72,
+    MediaList = 73,
+
+    // Media responses (server → client)
+    MediaUploadResult = 80,
+    MediaLoadResult = 81,
+    MediaDeleteResult = 82,
+    MediaListResult = 83,
+    MediaOperationError = 89
 }
 
 /// <summary>

--- a/src/CtfDeck.Data/Db/CtfDeckDbContext.cs
+++ b/src/CtfDeck.Data/Db/CtfDeckDbContext.cs
@@ -1,6 +1,8 @@
 using LiteDB;
 using CtfDeck.Data.PersistenceModels.Sessions;
 using CtfDeck.Data.PersistenceModels.Scripts;
+using CtfDeck.Data.PersistenceModels.WriteUps;
+using CtfDeck.Data.PersistenceModels.Media;
 
 namespace CtfDeck.Data.Db;
 
@@ -12,6 +14,8 @@ public sealed class CtfDeckDbContext : IDisposable
     private readonly LiteDatabase _database;
     private readonly ILiteCollection<Session> _sessions;
     private readonly ILiteCollection<CustomScript> _customScripts;
+    private readonly ILiteCollection<WriteUp> _writeUps;
+    private readonly ILiteCollection<PersistenceModels.Media.Media> _media;
     private bool _disposed;
 
     public CtfDeckDbContext(string? databasePath = null)
@@ -31,10 +35,20 @@ public sealed class CtfDeckDbContext : IDisposable
 
         _customScripts = _database.GetCollection<CustomScript>("customscripts");
         _customScripts.EnsureIndex(x => x.Id, unique: true);
+
+        _writeUps = _database.GetCollection<WriteUp>("writeups");
+        _writeUps.EnsureIndex(x => x.Id, unique: true);
+        _writeUps.EnsureIndex(x => x.SessionId);
+
+        _media = _database.GetCollection<PersistenceModels.Media.Media>("media");
+        _media.EnsureIndex(x => x.Id, unique: true);
+        _media.EnsureIndex(x => x.FileName);
     }
 
     public ILiteCollection<Session> Sessions => _sessions;
     public ILiteCollection<CustomScript> CustomScripts => _customScripts;
+    public ILiteCollection<WriteUp> WriteUps => _writeUps;
+    public ILiteCollection<PersistenceModels.Media.Media> Media => _media;
 
     private static void ConfigureBsonMapper()
     {
@@ -50,6 +64,8 @@ public sealed class CtfDeckDbContext : IDisposable
             BsonMapper.Global.Entity<HistoryEntry>().Id(x => x.Id);
             BsonMapper.Global.Entity<SessionTarget>().Id(x => x.Id);
             BsonMapper.Global.Entity<CustomScript>().Id(x => x.Id);
+            BsonMapper.Global.Entity<WriteUp>().Id(x => x.Id);
+            BsonMapper.Global.Entity<PersistenceModels.Media.Media>().Id(x => x.Id);
 
             _mapperConfigured = true;
         }

--- a/src/CtfDeck.Data/PersistenceModels/Media/Media.cs
+++ b/src/CtfDeck.Data/PersistenceModels/Media/Media.cs
@@ -1,0 +1,10 @@
+namespace CtfDeck.Data.PersistenceModels.Media;
+
+public class Media
+{
+    public Guid Id { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public string MimeType { get; set; } = string.Empty;
+    public byte[] Data { get; set; } = [];
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/CtfDeck.Data/PersistenceModels/WriteUps/WriteUp.cs
+++ b/src/CtfDeck.Data/PersistenceModels/WriteUps/WriteUp.cs
@@ -1,0 +1,11 @@
+namespace CtfDeck.Data.PersistenceModels.WriteUps;
+
+public class WriteUp
+{
+    public Guid Id { get; set; }
+    public Guid SessionId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/src/CtfDeck.Data/Repositories/Media/MediaRepository.cs
+++ b/src/CtfDeck.Data/Repositories/Media/MediaRepository.cs
@@ -1,0 +1,78 @@
+using CtfDeck.Abstractions.Ports.Media;
+using CtfDeck.Contracts.Models.Media;
+using CtfDeck.Data.Db;
+using PersistenceMedia = CtfDeck.Data.PersistenceModels.Media.Media;
+
+namespace CtfDeck.Data.Repositories.Media;
+
+public sealed class MediaRepository : IMediaRepository
+{
+    private readonly CtfDeckDbContext _context;
+    private readonly object _lock = new();
+
+    public MediaRepository(CtfDeckDbContext context)
+    {
+        _context = context;
+    }
+
+    public MediaDto Create(string fileName, string mimeType, byte[] data)
+    {
+        var model = new PersistenceMedia
+        {
+            Id = Guid.NewGuid(),
+            FileName = fileName,
+            MimeType = mimeType,
+            Data = data,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        lock (_lock)
+        {
+            _context.Media.Insert(model);
+        }
+
+        return ToDto(model);
+    }
+
+    public MediaDto? GetById(Guid id)
+    {
+        lock (_lock)
+        {
+            var model = _context.Media.FindById(id);
+            return model == null ? null : ToDto(model);
+        }
+    }
+
+    public List<MediaMetadataDto> GetAll()
+    {
+        lock (_lock)
+        {
+            return _context.Media.FindAll().Select(ToMetadataDto).ToList();
+        }
+    }
+
+    public bool Delete(Guid id)
+    {
+        lock (_lock)
+        {
+            return _context.Media.Delete(id);
+        }
+    }
+
+    private static MediaDto ToDto(PersistenceMedia m) => new()
+    {
+        Id = m.Id,
+        FileName = m.FileName ?? "",
+        MimeType = m.MimeType ?? "",
+        Data = m.Data ?? [],
+        CreatedAt = m.CreatedAt
+    };
+
+    private static MediaMetadataDto ToMetadataDto(PersistenceMedia m) => new()
+    {
+        Id = m.Id,
+        FileName = m.FileName ?? "",
+        MimeType = m.MimeType ?? "",
+        CreatedAt = m.CreatedAt
+    };
+}

--- a/src/CtfDeck.Data/Repositories/WriteUps/WriteUpRepository.cs
+++ b/src/CtfDeck.Data/Repositories/WriteUps/WriteUpRepository.cs
@@ -1,0 +1,100 @@
+using CtfDeck.Abstractions.Ports.WriteUps;
+using CtfDeck.Contracts.Models.WriteUps;
+using CtfDeck.Data.Db;
+using CtfDeck.Data.PersistenceModels.WriteUps;
+
+namespace CtfDeck.Data.Repositories.WriteUps;
+
+public sealed class WriteUpRepository : IWriteUpRepository
+{
+    private readonly CtfDeckDbContext _context;
+    private readonly object _lock = new();
+
+    public WriteUpRepository(CtfDeckDbContext context)
+    {
+        _context = context;
+    }
+
+    public WriteUpDto Create(Guid sessionId, string name)
+    {
+        var now = DateTime.UtcNow;
+        var model = new WriteUp
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            Name = name,
+            Content = "",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        lock (_lock)
+        {
+            _context.WriteUps.Insert(model);
+        }
+
+        return ToDto(model);
+    }
+
+    public WriteUpDto? GetById(Guid id)
+    {
+        lock (_lock)
+        {
+            var model = _context.WriteUps.FindById(id);
+            return model == null ? null : ToDto(model);
+        }
+    }
+
+    public List<WriteUpMetadataDto> GetBySessionId(Guid sessionId)
+    {
+        lock (_lock)
+        {
+            return _context.WriteUps
+                .Find(w => w.SessionId == sessionId)
+                .Select(ToMetadataDto)
+                .ToList();
+        }
+    }
+
+    public bool Update(Guid id, string name, string content)
+    {
+        lock (_lock)
+        {
+            var model = _context.WriteUps.FindById(id);
+            if (model == null) return false;
+
+            model.Name = name;
+            model.Content = content;
+            model.UpdatedAt = DateTime.UtcNow;
+
+            return _context.WriteUps.Update(model);
+        }
+    }
+
+    public bool Delete(Guid id)
+    {
+        lock (_lock)
+        {
+            return _context.WriteUps.Delete(id);
+        }
+    }
+
+    private static WriteUpDto ToDto(WriteUp m) => new()
+    {
+        Id = m.Id,
+        SessionId = m.SessionId,
+        Name = m.Name ?? "",
+        Content = m.Content ?? "",
+        CreatedAt = m.CreatedAt,
+        UpdatedAt = m.UpdatedAt
+    };
+
+    private static WriteUpMetadataDto ToMetadataDto(WriteUp m) => new()
+    {
+        Id = m.Id,
+        SessionId = m.SessionId,
+        Name = m.Name ?? "",
+        CreatedAt = m.CreatedAt,
+        UpdatedAt = m.UpdatedAt
+    };
+}

--- a/src/CtfDeck.ServerWs/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.ServerWs/WebSocket/WebSocketServer.cs
@@ -3,15 +3,21 @@ using System.Net;
 using System.Net.WebSockets;
 using CtfDeck.Abstractions.Ports.Scripts;
 using CtfDeck.Abstractions.Ports.Sessions;
+using CtfDeck.Abstractions.Ports.WriteUps;
+using CtfDeck.Abstractions.Ports.Media;
 
 using CtfDeck.Contracts.Transport;
 
 using CtfDeck.Data.Db;
 using CtfDeck.Data.Repositories.Sessions;
 using CtfDeck.Data.Repositories.Scripts;
+using CtfDeck.Data.Repositories.WriteUps;
+using CtfDeck.Data.Repositories.Media;
 
 using CtfDeck.Terminal.Features.Sessions;
 using CtfDeck.Terminal.Features.Scripts;
+using CtfDeck.Terminal.Features.WriteUps;
+using CtfDeck.Terminal.Features.Media;
 using CtfDeck.Terminal.Handlers;
 
 namespace CtfDeck.ServerWs.WebSocket;
@@ -49,6 +55,8 @@ public class WebSocketServer
         // Repositories (as ports)
         ISessionRepository sessionRepository = new SessionRepository(_dbContext);
         ICustomScriptRepository customScriptRepository = new CustomScriptRepository(_dbContext);
+        IWriteUpRepository writeUpRepository = new WriteUpRepository(_dbContext);
+        IMediaRepository mediaRepository = new MediaRepository(_dbContext);
 
         // Services / handlers
         var sessionService = new SessionService(sessionRepository);
@@ -56,11 +64,15 @@ public class WebSocketServer
         _commandDispatcher = new CommandDispatcher(_activeSessionManager, _cancellationTokenSource.Token);
 
         var customScriptService = new CustomScriptService(customScriptRepository);
+        var writeUpService = new WriteUpService(writeUpRepository);
+        var mediaService = new MediaService(mediaRepository);
 
         _messageHandlers =
         [
             new SessionMessageHandler(sessionService, _activeSessionManager),
-            new CustomScriptMessageHandler(customScriptService)
+            new CustomScriptMessageHandler(customScriptService),
+            new WriteUpMessageHandler(writeUpService),
+            new MediaMessageHandler(mediaService)
         ];
     }
 
@@ -204,7 +216,7 @@ public class WebSocketServer
 
     private async Task HandleClientMessagesAsync(ClientContext ctx)
     {
-        var buffer = new byte[1024 * 64]; // 64KB buffer for session data
+        var buffer = new byte[1024 * 64]; // 64KB receive buffer
         var webSocket = ctx.WebSocket;
         var clientId = ctx.ClientId;
 
@@ -212,24 +224,24 @@ public class WebSocketServer
         {
             while (webSocket.State == WebSocketState.Open && !_cancellationTokenSource.Token.IsCancellationRequested)
             {
-                var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), _cancellationTokenSource.Token);
+                var (message, messageType) = await ReceiveFullMessageAsync(webSocket, buffer, _cancellationTokenSource.Token);
 
-                if (result.MessageType == WebSocketMessageType.Close)
+                if (messageType == WebSocketMessageType.Close)
                 {
                     await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
                     break;
                 }
 
-                if (result.MessageType == WebSocketMessageType.Binary)
+                if (messageType == WebSocketMessageType.Binary)
                 {
-                    var messageType = (MessageType)buffer[0];
+                    var protocolType = (MessageType)message.Span[0];
 
-                    switch (messageType)
+                    switch (protocolType)
                     {
                         case MessageType.CommandExecute:
                             {
-                                // Copy buffer before dispatching (buffer is reused by receive loop)
-                                var messageDataCopy = buffer.AsSpan(0, result.Count).ToArray();
+                                // Copy for fire-and-forget dispatch (message may be backed by reusable buffer)
+                                var messageDataCopy = message.ToArray();
                                 var command = WebSocketCommand.Deserialize(messageDataCopy);
                                 var trimmedCommand = command.Command.Trim();
 
@@ -246,14 +258,14 @@ public class WebSocketServer
 
                         case MessageType.CommandKill:
                             {
-                                var killCommandId = new CommandKillReader(buffer.AsSpan(0, result.Count)).CommandId;
+                                var killCommandId = new CommandKillReader(message.Span).CommandId;
                                 await _commandDispatcher.HandleKillAsync(ctx, killCommandId);
                                 break;
                             }
 
                         case MessageType.PasswordProvide:
                             {
-                                var reader = new PasswordProvideReader(buffer.AsSpan(0, result.Count));
+                                var reader = new PasswordProvideReader(message.Span);
                                 var pwd = reader.PasswordLength == 0 ? null : reader.GetPassword();
 
                                 if (ctx.SudoWaiters.TryRemove(reader.MessageId, out var tcs))
@@ -265,12 +277,11 @@ public class WebSocketServer
 
                         default:
                             {
-                                var messageData = buffer.AsMemory(0, result.Count);
                                 var handled = false;
 
                                 foreach (var handler in _messageHandlers)
                                 {
-                                    if (await handler.TryHandleAsync(clientId, messageData, ctx.Sender.SendAsync, _cancellationTokenSource.Token))
+                                    if (await handler.TryHandleAsync(clientId, message, ctx.Sender.SendAsync, _cancellationTokenSource.Token))
                                     {
                                         handled = true;
                                         break;
@@ -278,7 +289,7 @@ public class WebSocketServer
                                 }
 
                                 if (!handled)
-                                    Console.WriteLine($"Unknown message from client {clientId}: type={buffer[0]}, size={result.Count}");
+                                    Console.WriteLine($"Unknown message from client {clientId}: type={message.Span[0]}, size={message.Length}");
 
                                 break;
                             }
@@ -298,6 +309,36 @@ public class WebSocketServer
         {
             Console.WriteLine($"Error handling messages for client {clientId}: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Reads a complete WebSocket message, accumulating frames if fragmented.
+    /// For single-frame messages (vast majority), returns a slice of the shared buffer — zero allocation.
+    /// For multi-frame messages (large media uploads), allocates a new array to hold the full payload.
+    /// </summary>
+    private static async Task<(ReadOnlyMemory<byte> Message, WebSocketMessageType Type)> ReceiveFullMessageAsync(
+        System.Net.WebSockets.WebSocket webSocket, byte[] buffer, CancellationToken ct)
+    {
+        var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+
+        if (result.MessageType == WebSocketMessageType.Close)
+            return (ReadOnlyMemory<byte>.Empty, WebSocketMessageType.Close);
+
+        // Fast path: single frame fits in buffer (>99% of messages)
+        if (result.EndOfMessage)
+            return (new ReadOnlyMemory<byte>(buffer, 0, result.Count), result.MessageType);
+
+        // Slow path: fragmented message — accumulate into a MemoryStream
+        var ms = new MemoryStream(result.Count * 2);
+        ms.Write(buffer, 0, result.Count);
+
+        while (!result.EndOfMessage)
+        {
+            result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+            ms.Write(buffer, 0, result.Count);
+        }
+
+        return (ms.GetBuffer().AsMemory(0, (int)ms.Length), result.MessageType);
     }
 
     public bool IsRunning => _isRunning;

--- a/src/CtfDeck.Terminal/Features/Media/MediaService.cs
+++ b/src/CtfDeck.Terminal/Features/Media/MediaService.cs
@@ -1,0 +1,26 @@
+using CtfDeck.Contracts.Models.Media;
+using CtfDeck.Abstractions.Ports.Media;
+
+namespace CtfDeck.Terminal.Features.Media;
+
+public class MediaService
+{
+    private readonly IMediaRepository _repository;
+
+    public MediaService(IMediaRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public MediaDto Create(string fileName, string mimeType, byte[] data)
+        => _repository.Create(fileName, mimeType, data);
+
+    public MediaDto? GetById(Guid id)
+        => _repository.GetById(id);
+
+    public List<MediaMetadataDto> GetAll()
+        => _repository.GetAll();
+
+    public bool Delete(Guid id)
+        => _repository.Delete(id);
+}

--- a/src/CtfDeck.Terminal/Features/WriteUps/WriteUpService.cs
+++ b/src/CtfDeck.Terminal/Features/WriteUps/WriteUpService.cs
@@ -1,0 +1,29 @@
+using CtfDeck.Contracts.Models.WriteUps;
+using CtfDeck.Abstractions.Ports.WriteUps;
+
+namespace CtfDeck.Terminal.Features.WriteUps;
+
+public class WriteUpService
+{
+    private readonly IWriteUpRepository _repository;
+
+    public WriteUpService(IWriteUpRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public WriteUpDto Create(Guid sessionId, string name)
+        => _repository.Create(sessionId, name);
+
+    public WriteUpDto? GetById(Guid id)
+        => _repository.GetById(id);
+
+    public List<WriteUpMetadataDto> GetBySessionId(Guid sessionId)
+        => _repository.GetBySessionId(sessionId);
+
+    public bool Update(Guid id, string name, string content)
+        => _repository.Update(id, name, content);
+
+    public bool Delete(Guid id)
+        => _repository.Delete(id);
+}

--- a/src/CtfDeck.Terminal/Handlers/MediaMessageHandler.cs
+++ b/src/CtfDeck.Terminal/Handlers/MediaMessageHandler.cs
@@ -1,0 +1,67 @@
+using CtfDeck.Terminal.Features.Media;
+using CtfDeck.Contracts.Transport;
+using CtfDeck.Contracts.Protocols.Media;
+
+namespace CtfDeck.Terminal.Handlers;
+
+public sealed class MediaMessageHandler : MessageHandlerBase
+{
+    private const int MaxUploadSize = 8 * 1024 * 1024; // 8 MB
+
+    private readonly MediaService _mediaService;
+
+    public MediaMessageHandler(MediaService mediaService)
+    {
+        _mediaService = mediaService;
+    }
+
+    protected override bool CanHandle(MessageType type)
+        => MediaProtocolDeserializer.IsMediaMessage(type);
+
+    protected override byte[] SerializeError(Guid messageId, string error)
+        => MediaProtocolSerializer.SerializeError(messageId, error);
+
+    protected override byte[] Dispatch(string clientId, MessageType type, ReadOnlySpan<byte> data)
+    {
+        return type switch
+        {
+            MessageType.MediaUpload => HandleUpload(data),
+            MessageType.MediaLoad => HandleLoad(data),
+            MessageType.MediaDelete => HandleDelete(data),
+            MessageType.MediaList => HandleList(data),
+            _ => throw new InvalidOperationException($"Unknown media message type: {type}")
+        };
+    }
+
+    private byte[] HandleUpload(ReadOnlySpan<byte> data)
+    {
+        var request = new MediaUploadRequest(data);
+
+        if (request.Data.Length > MaxUploadSize)
+            throw new InvalidOperationException($"File exceeds maximum upload size of {MaxUploadSize / (1024 * 1024)} MB");
+
+        var media = _mediaService.Create(request.FileName, request.MimeType, request.Data.ToArray());
+        return MediaProtocolSerializer.SerializeUploadResult(request.MessageId, true, media.Id);
+    }
+
+    private byte[] HandleLoad(ReadOnlySpan<byte> data)
+    {
+        var request = new MediaLoadRequest(data);
+        var media = _mediaService.GetById(request.MediaId);
+        return MediaProtocolSerializer.SerializeLoadResult(request.MessageId, media != null, media);
+    }
+
+    private byte[] HandleDelete(ReadOnlySpan<byte> data)
+    {
+        var request = new MediaDeleteRequest(data);
+        var success = _mediaService.Delete(request.MediaId);
+        return MediaProtocolSerializer.SerializeDeleteResult(request.MessageId, success);
+    }
+
+    private byte[] HandleList(ReadOnlySpan<byte> data)
+    {
+        var request = new MediaListRequest(data);
+        var mediaList = _mediaService.GetAll();
+        return MediaProtocolSerializer.SerializeListResult(request.MessageId, mediaList);
+    }
+}

--- a/src/CtfDeck.Terminal/Handlers/WriteUpMessageHandler.cs
+++ b/src/CtfDeck.Terminal/Handlers/WriteUpMessageHandler.cs
@@ -1,0 +1,69 @@
+using CtfDeck.Terminal.Features.WriteUps;
+using CtfDeck.Contracts.Transport;
+using CtfDeck.Contracts.Protocols.WriteUp;
+
+namespace CtfDeck.Terminal.Handlers;
+
+public sealed class WriteUpMessageHandler : MessageHandlerBase
+{
+    private readonly WriteUpService _writeUpService;
+
+    public WriteUpMessageHandler(WriteUpService writeUpService)
+    {
+        _writeUpService = writeUpService;
+    }
+
+    protected override bool CanHandle(MessageType type)
+        => WriteUpProtocolDeserializer.IsWriteUpMessage(type);
+
+    protected override byte[] SerializeError(Guid messageId, string error)
+        => WriteUpProtocolSerializer.SerializeError(messageId, error);
+
+    protected override byte[] Dispatch(string clientId, MessageType type, ReadOnlySpan<byte> data)
+    {
+        return type switch
+        {
+            MessageType.WriteUpCreate => HandleCreate(data),
+            MessageType.WriteUpUpdate => HandleUpdate(data),
+            MessageType.WriteUpDelete => HandleDelete(data),
+            MessageType.WriteUpList => HandleList(data),
+            MessageType.WriteUpLoad => HandleLoad(data),
+            _ => throw new InvalidOperationException($"Unknown write-up message type: {type}")
+        };
+    }
+
+    private byte[] HandleCreate(ReadOnlySpan<byte> data)
+    {
+        var request = new WriteUpCreateRequest(data);
+        var writeUp = _writeUpService.Create(request.SessionId, request.Name);
+        return WriteUpProtocolSerializer.SerializeCreateResult(request.MessageId, true, writeUp.Id);
+    }
+
+    private byte[] HandleUpdate(ReadOnlySpan<byte> data)
+    {
+        var request = new WriteUpUpdateRequest(data);
+        var success = _writeUpService.Update(request.WriteUpId, request.Name, request.Content);
+        return WriteUpProtocolSerializer.SerializeUpdateResult(request.MessageId, success);
+    }
+
+    private byte[] HandleDelete(ReadOnlySpan<byte> data)
+    {
+        var request = new WriteUpDeleteRequest(data);
+        var success = _writeUpService.Delete(request.WriteUpId);
+        return WriteUpProtocolSerializer.SerializeDeleteResult(request.MessageId, success);
+    }
+
+    private byte[] HandleList(ReadOnlySpan<byte> data)
+    {
+        var request = new WriteUpListRequest(data);
+        var writeUps = _writeUpService.GetBySessionId(request.SessionId);
+        return WriteUpProtocolSerializer.SerializeListResult(request.MessageId, writeUps);
+    }
+
+    private byte[] HandleLoad(ReadOnlySpan<byte> data)
+    {
+        var request = new WriteUpLoadRequest(data);
+        var writeUp = _writeUpService.GetById(request.WriteUpId);
+        return WriteUpProtocolSerializer.SerializeLoadResult(request.MessageId, writeUp != null, writeUp);
+    }
+}

--- a/tests/CtfDeck.Tests/Media/MediaProtocolTests.cs
+++ b/tests/CtfDeck.Tests/Media/MediaProtocolTests.cs
@@ -1,0 +1,240 @@
+using CtfDeck.Contracts.Models.Media;
+using CtfDeck.Contracts.Protocols.Media;
+using CtfDeck.Contracts.Transport;
+using FluentAssertions;
+
+namespace CtfDeck.Tests.Media;
+
+public class MediaProtocolTests
+{
+    [Fact]
+    public void MediaUploadRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var fileName = "screenshot.png";
+        var mimeType = "image/png";
+        var fileData = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }; // PNG magic bytes
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaUpload);
+        writer.WriteGuid(messageId);
+        writer.WriteString(fileName);
+        writer.WriteString(mimeType);
+        writer.WriteInt32(fileData.Length);
+        writer.WriteBytes(fileData);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new MediaUploadRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.FileName.Should().Be(fileName);
+        request.MimeType.Should().Be(mimeType);
+        request.Data.ToArray().Should().BeEquivalentTo(fileData);
+    }
+
+    [Fact]
+    public void MediaLoadRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var mediaId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaLoad);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(mediaId);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new MediaLoadRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.MediaId.Should().Be(mediaId);
+    }
+
+    [Fact]
+    public void MediaDeleteRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var mediaId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaDelete);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(mediaId);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new MediaDeleteRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.MediaId.Should().Be(mediaId);
+    }
+
+    [Fact]
+    public void MediaListRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaList);
+        writer.WriteGuid(messageId);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new MediaListRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+    }
+
+    [Fact]
+    public void SerializeUploadResult_ShouldRoundTrip()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var mediaId = Guid.NewGuid();
+
+        // Act
+        var bytes = MediaProtocolSerializer.SerializeUploadResult(messageId, true, mediaId);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.MediaUploadResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1); // success
+        var resultMediaId = new Guid(bytes.AsSpan(18, 16));
+        resultMediaId.Should().Be(mediaId);
+    }
+
+    [Fact]
+    public void SerializeLoadResult_Success_ShouldContainFullData()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var fileData = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10 }; // JPEG magic
+        var media = new MediaDto
+        {
+            Id = Guid.NewGuid(),
+            FileName = "photo.jpg",
+            MimeType = "image/jpeg",
+            Data = fileData,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        // Act
+        var bytes = MediaProtocolSerializer.SerializeLoadResult(messageId, true, media);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.MediaLoadResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1); // success
+        var resultMediaId = new Guid(bytes.AsSpan(18, 16));
+        resultMediaId.Should().Be(media.Id);
+    }
+
+    [Fact]
+    public void SerializeLoadResult_NotFound_ShouldBeMinimal()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var bytes = MediaProtocolSerializer.SerializeLoadResult(messageId, false, null);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.MediaLoadResult);
+        bytes[17].Should().Be(0); // not success
+        bytes.Length.Should().Be(18); // type + msgId + success only
+    }
+
+    [Fact]
+    public void SerializeListResult_ShouldSerializeMultipleEntries()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var mediaList = new List<MediaMetadataDto>
+        {
+            new() { Id = Guid.NewGuid(), FileName = "screen1.png", MimeType = "image/png", CreatedAt = now },
+            new() { Id = Guid.NewGuid(), FileName = "exploit.py", MimeType = "text/x-python", CreatedAt = now },
+            new() { Id = Guid.NewGuid(), FileName = "flag.txt", MimeType = "text/plain", CreatedAt = now }
+        };
+
+        // Act
+        var bytes = MediaProtocolSerializer.SerializeListResult(messageId, mediaList);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.MediaListResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        var count = BitConverter.ToInt32(bytes.AsSpan(17, 4));
+        count.Should().Be(3);
+    }
+
+    [Fact]
+    public void SerializeDeleteResult_ShouldWork()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var bytes = MediaProtocolSerializer.SerializeDeleteResult(messageId, true);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.MediaDeleteResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1);
+    }
+
+    [Fact]
+    public void MediaUploadRequest_LargeData_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var fileName = "large_image.bmp";
+        var mimeType = "image/bmp";
+        var fileData = new byte[8192];
+        new Random(42).NextBytes(fileData);
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.MediaUpload);
+        writer.WriteGuid(messageId);
+        writer.WriteString(fileName);
+        writer.WriteString(mimeType);
+        writer.WriteInt32(fileData.Length);
+        writer.WriteBytes(fileData);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new MediaUploadRequest(data);
+
+        // Assert
+        request.FileName.Should().Be(fileName);
+        request.MimeType.Should().Be(mimeType);
+        request.Data.Length.Should().Be(8192);
+        request.Data.ToArray().Should().BeEquivalentTo(fileData);
+    }
+
+    [Fact]
+    public void IsMediaMessage_ShouldDetectCorrectRange()
+    {
+        MediaProtocolDeserializer.IsMediaMessage(MessageType.MediaUpload).Should().BeTrue();
+        MediaProtocolDeserializer.IsMediaMessage(MessageType.MediaLoad).Should().BeTrue();
+        MediaProtocolDeserializer.IsMediaMessage(MessageType.MediaDelete).Should().BeTrue();
+        MediaProtocolDeserializer.IsMediaMessage(MessageType.MediaList).Should().BeTrue();
+
+        MediaProtocolDeserializer.IsMediaMessage(MessageType.WriteUpCreate).Should().BeFalse();
+        MediaProtocolDeserializer.IsMediaMessage(MessageType.CustomScriptList).Should().BeFalse();
+        MediaProtocolDeserializer.IsMediaMessage(MessageType.SessionCreate).Should().BeFalse();
+    }
+}

--- a/tests/CtfDeck.Tests/WriteUp/WriteUpProtocolTests.cs
+++ b/tests/CtfDeck.Tests/WriteUp/WriteUpProtocolTests.cs
@@ -1,0 +1,247 @@
+using CtfDeck.Contracts.Models.WriteUps;
+using CtfDeck.Contracts.Protocols.WriteUp;
+using CtfDeck.Contracts.Transport;
+using FluentAssertions;
+
+namespace CtfDeck.Tests.WriteUp;
+
+public class WriteUpProtocolTests
+{
+    [Fact]
+    public void WriteUpCreateRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var name = "My CTF WriteUp";
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpCreate);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(sessionId);
+        writer.WriteString(name);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new WriteUpCreateRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.SessionId.Should().Be(sessionId);
+        request.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void WriteUpUpdateRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var writeUpId = Guid.NewGuid();
+        var name = "Updated Title";
+        var content = "# WriteUp\n\nThis is the **markdown** content.\n\n## Steps\n1. Recon\n2. Exploit";
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpUpdate);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(writeUpId);
+        writer.WriteString(name);
+        writer.WriteString(content);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new WriteUpUpdateRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.WriteUpId.Should().Be(writeUpId);
+        request.Name.Should().Be(name);
+        request.Content.Should().Be(content);
+    }
+
+    [Fact]
+    public void WriteUpDeleteRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var writeUpId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpDelete);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(writeUpId);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new WriteUpDeleteRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.WriteUpId.Should().Be(writeUpId);
+    }
+
+    [Fact]
+    public void WriteUpListRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpList);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(sessionId);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new WriteUpListRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.SessionId.Should().Be(sessionId);
+    }
+
+    [Fact]
+    public void WriteUpLoadRequest_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var writeUpId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpLoad);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(writeUpId);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new WriteUpLoadRequest(data);
+
+        // Assert
+        request.MessageId.Should().Be(messageId);
+        request.WriteUpId.Should().Be(writeUpId);
+    }
+
+    [Fact]
+    public void SerializeCreateResult_ShouldRoundTrip()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var writeUpId = Guid.NewGuid();
+
+        // Act
+        var bytes = WriteUpProtocolSerializer.SerializeCreateResult(messageId, true, writeUpId);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.WriteUpCreateResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1); // success
+        var resultWriteUpId = new Guid(bytes.AsSpan(18, 16));
+        resultWriteUpId.Should().Be(writeUpId);
+    }
+
+    [Fact]
+    public void SerializeListResult_ShouldSerializeMultipleEntries()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var writeUps = new List<WriteUpMetadataDto>
+        {
+            new() { Id = Guid.NewGuid(), SessionId = Guid.NewGuid(), Name = "WriteUp 1", CreatedAt = now, UpdatedAt = now },
+            new() { Id = Guid.NewGuid(), SessionId = Guid.NewGuid(), Name = "WriteUp 2", CreatedAt = now, UpdatedAt = now }
+        };
+
+        // Act
+        var bytes = WriteUpProtocolSerializer.SerializeListResult(messageId, writeUps);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.WriteUpListResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        var count = BitConverter.ToInt32(bytes.AsSpan(17, 4));
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public void SerializeLoadResult_Success_ShouldContainFullData()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var writeUp = new WriteUpDto
+        {
+            Id = Guid.NewGuid(),
+            SessionId = Guid.NewGuid(),
+            Name = "Test WriteUp",
+            Content = "# Hello\n\nWorld",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Act
+        var bytes = WriteUpProtocolSerializer.SerializeLoadResult(messageId, true, writeUp);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.WriteUpLoadResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1); // success
+        var resultId = new Guid(bytes.AsSpan(18, 16));
+        resultId.Should().Be(writeUp.Id);
+    }
+
+    [Fact]
+    public void SerializeLoadResult_NotFound_ShouldBeMinimal()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var bytes = WriteUpProtocolSerializer.SerializeLoadResult(messageId, false, null);
+
+        // Assert
+        bytes[0].Should().Be((byte)MessageType.WriteUpLoadResult);
+        bytes[17].Should().Be(0); // not success
+        bytes.Length.Should().Be(18); // type + msgId + success only
+    }
+
+    [Fact]
+    public void WriteUpUpdateRequest_WithUnicode_ShouldDeserializeCorrectly()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var writeUpId = Guid.NewGuid();
+        var name = "CTF Challenge: Buffer Overflow";
+        var content = "## Exploit\n\nUsed pwntools to send payload:\n```python\npayload = b'A' * 64 + p64(0xdeadbeef)\n```";
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpUpdate);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(writeUpId);
+        writer.WriteString(name);
+        writer.WriteString(content);
+        var data = writer.ToArray();
+
+        // Act
+        var request = new WriteUpUpdateRequest(data);
+
+        // Assert
+        request.Name.Should().Be(name);
+        request.Content.Should().Be(content);
+    }
+
+    [Fact]
+    public void IsWriteUpMessage_ShouldDetectCorrectRange()
+    {
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.WriteUpCreate).Should().BeTrue();
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.WriteUpUpdate).Should().BeTrue();
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.WriteUpDelete).Should().BeTrue();
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.WriteUpList).Should().BeTrue();
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.WriteUpLoad).Should().BeTrue();
+
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.CustomScriptList).Should().BeFalse();
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.MediaUpload).Should().BeFalse();
+        WriteUpProtocolDeserializer.IsWriteUpMessage(MessageType.SessionCreate).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for CTF write-ups and media (binary blobs) in the backend, including protocol extensions, database schema changes, and documentation updates. The changes add full CRUD operations and storage for write-ups (reports) linked to sessions, as well as global binary media storage with upload limits. The repository structure and database models are updated to reflect these new features.

**CTF Write-Up Support**

* Added a new `writeups` collection to the database schema, with indexes for `_id` and `SessionId` and a detailed document schema for write-ups, including examples. [[1]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR34-R53) [[2]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR253-R323)
* Extended the binary protocol to include message types and formats for write-up CRUD operations, listing, loading, and error handling. [[1]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR107-R126) [[2]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR912-R1254)

**Media (Binary Blob) Support**

* Added a new `media` collection to the database schema, with indexes for `_id` and `FileName` and a detailed document schema for media entries, including examples. [[1]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR34-R53) [[2]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR253-R323)
* Extended the binary protocol to include message types and formats for media upload, load, delete, list, and error handling, including support for multi-frame WebSocket messages and an 8 MB per-file upload limit. [[1]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR107-R126) [[2]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR912-R1254)

**Repository and Service Structure Updates**

* Updated repository and service structure in the documentation to include `WriteUpRepository`, `MediaRepository`, `WriteUpService`, and `MediaService`, and reflected the new `CtfDeckDbContext` and persistence model locations. [[1]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR374-R386) [[2]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bL307-R425)
* Updated code references and project structure documentation to show new features, handlers, DTOs, ports, and tests for write-ups and media. [[1]](diffhunk://#diff-dadd9786ef8658411f5a35c9f44b0668edb3b7d6518612f2fe4490b1018baf07L18-R79) [[2]](diffhunk://#diff-dadd9786ef8658411f5a35c9f44b0668edb3b7d6518612f2fe4490b1018baf07L52-R96)

**Constraints and Limits**

* Documented new constraints: 8 MB max media file size, unlimited write-ups per session, and unlimited media entries globally.

**Database Context Registration**

* Registered new entities (`WriteUp`, `Media`) in the LiteDB context mapping.