### PR TITLE
feature/project management back

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,4 +1,4 @@
-# Database Schema - Session Management
+# Database Schema
 
 ## Overview
 
@@ -21,6 +21,7 @@ Main collection storing all session documents.
 |-------|------|--------|
 | `_id` (Id) | GUID | Yes |
 | `Name` | String | No |
+| `ProjectId` | GUID | No |
 
 ### `customscripts`
 
@@ -40,6 +41,7 @@ Collection storing CTF write-ups (reports). Each write-up is linked to a session
 |-------|------|--------|
 | `_id` (Id) | GUID | Yes |
 | `SessionId` | GUID | No |
+| `FolderId` | GUID | No |
 
 ### `media`
 
@@ -50,6 +52,16 @@ Collection storing binary blobs (images, videos, PDFs, etc.) that can be referen
 |-------|------|--------|
 | `_id` (Id) | GUID | Yes |
 | `FileName` | String | No |
+
+### `projects`
+
+Collection storing CTF projects. Projects group sessions and write-up folders. Folders are embedded in the project document.
+
+**Indexes:**
+| Field | Type | Unique |
+|-------|------|--------|
+| `_id` (Id) | GUID | Yes |
+| `Name` | String | No |
 
 ---
 
@@ -66,6 +78,7 @@ Root document representing a CTF session.
   "Description": "string",
   "CreatedAt": "DateTime (UTC)",
   "UpdatedAt": "DateTime (UTC)",
+  "ProjectId": "GUID | null",
   "History": [HistoryEntry],
   "Targets": [SessionTarget]
 }
@@ -78,6 +91,7 @@ Root document representing a CTF session.
 | `Description` | `string` | Session description (default empty) |
 | `CreatedAt` | `DateTime` | Creation timestamp (UTC) |
 | `UpdatedAt` | `DateTime` | Last modification timestamp (UTC) |
+| `ProjectId` | `Guid?` | FK to Project (nullable, null = unlinked) |
 | `History` | `List<HistoryEntry>` | Embedded array of command history |
 | `Targets` | `List<SessionTarget>` | Embedded array of targets |
 
@@ -258,6 +272,7 @@ Root document representing a CTF write-up (report).
 {
   "_id": "GUID",
   "SessionId": "GUID",
+  "FolderId": "GUID | null",
   "Name": "string",
   "Content": "string (markdown)",
   "CreatedAt": "DateTime (UTC)",
@@ -269,6 +284,7 @@ Root document representing a CTF write-up (report).
 |-------|------|-------------|
 | `_id` | `Guid` | Primary key, auto-generated |
 | `SessionId` | `Guid` | Foreign key to Session (mandatory) |
+| `FolderId` | `Guid?` | FK to ProjectFolder (nullable, null = unlinked) |
 | `Name` | `string` | Write-up title |
 | `Content` | `string` | Markdown body (default empty) |
 | `CreatedAt` | `DateTime` | Creation timestamp (UTC) |
@@ -321,6 +337,78 @@ Root document representing a binary blob (image, video, PDF, etc.).
 }
 ```
 
+### Project
+
+Root document representing a CTF project. Groups sessions and write-up folders.
+
+```json
+{
+  "_id": "GUID",
+  "Name": "string",
+  "Description": "string",
+  "CreatedAt": "DateTime (UTC)",
+  "UpdatedAt": "DateTime (UTC)",
+  "Folders": [ProjectFolder]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_id` | `Guid` | Primary key, auto-generated |
+| `Name` | `string` | Project display name |
+| `Description` | `string` | Project description (default empty) |
+| `CreatedAt` | `DateTime` | Creation timestamp (UTC) |
+| `UpdatedAt` | `DateTime` | Last modification timestamp (UTC) |
+| `Folders` | `List<ProjectFolder>` | Embedded array of folders |
+
+---
+
+### ProjectFolder (Embedded)
+
+Represents a folder within a project for organizing write-ups.
+
+```json
+{
+  "_id": "GUID",
+  "Name": "string",
+  "IsSystem": "bool"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_id` | `Guid` | Unique identifier |
+| `Name` | `string` | Folder display name |
+| `IsSystem` | `bool` | `true` for auto-created folders (e.g., "Report") — cannot be deleted or renamed |
+
+**Notes:**
+- A "Report" folder with `IsSystem = true` is automatically created when a project is created.
+- System folders are protected from deletion and renaming.
+
+### Project Example
+
+```json
+{
+  "_id": { "$guid": "000e1176-1ce1-4aca-8cd4-190194e6ffb2" },
+  "Name": "HTB Season 2",
+  "Description": "HackTheBox machines for season 2",
+  "CreatedAt": { "$date": "2024-03-01T09:00:00Z" },
+  "UpdatedAt": { "$date": "2024-03-01T09:00:00Z" },
+  "Folders": [
+    {
+      "_id": { "$guid": "2f7dc82b-9de2-4ba4-b7c1-c1bb763cb50b" },
+      "Name": "Report",
+      "IsSystem": true
+    },
+    {
+      "_id": { "$guid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890" },
+      "Name": "Exploits",
+      "IsSystem": false
+    }
+  ]
+}
+```
+
 ---
 
 ## Configuration
@@ -336,13 +424,15 @@ BsonMapper.Global.Entity<SessionTarget>().Id(x => x.Id);
 BsonMapper.Global.Entity<CustomScript>().Id(x => x.Id);
 BsonMapper.Global.Entity<WriteUp>().Id(x => x.Id);
 BsonMapper.Global.Entity<Media>().Id(x => x.Id);
+BsonMapper.Global.Entity<Project>().Id(x => x.Id);
+BsonMapper.Global.Entity<ProjectFolder>().Id(x => x.Id);
 ```
 
 ### Connection Strings
 
 | Mode | Connection String |
 |------|------------------|
-| Production | `Filename=ctfdeck_sessions.db` |
+| Production | `Filename=ctfdeck.db` |
 | In-Memory | `Filename=:memory:;Mode=Memory;Cache=Shared` |
 
 ---
@@ -380,6 +470,11 @@ Frontend (Electron/Angular)
          │                              │
          │                              ▼
          │                       MediaRepository
+         │                              │
+         ├── Project Commands ──► ProjectService
+         │                              │
+         │                              ▼
+         │                     ProjectRepository
          │                              │
          └──────────────────────────────┤
                                         ▼
@@ -423,3 +518,6 @@ Frontend (Electron/Angular)
 | Script Service | `src/CtfDeck.Terminal/Features/Scripts/CustomScriptService.cs` |
 | WriteUp Service | `src/CtfDeck.Terminal/Features/WriteUps/WriteUpService.cs` |
 | Media Service | `src/CtfDeck.Terminal/Features/Media/MediaService.cs` |
+| Project Persistence Model | `src/CtfDeck.Data/PersistenceModels/Projects/` |
+| Project Repository | `src/CtfDeck.Data/Repositories/Projects/ProjectRepository.cs` |
+| Project Service | `src/CtfDeck.Terminal/Features/Projects/ProjectService.cs` |

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -32,7 +32,8 @@ Business logic layer. Handles terminal execution, features, and message handlers
 - **`Features/Scripts/`**: Custom script CRUD wrapper.
 - **`Features/WriteUps/`**: Write-up CRUD service.
 - **`Features/Media/`**: Media CRUD service.
-- **`Handlers/`**: Message handler pipeline (`SessionMessageHandler`, `CustomScriptMessageHandler`, `WriteUpMessageHandler`, `MediaMessageHandler`).
+- **`Features/Projects/`**: Project CRUD, folder management, session assignment, write-up folder assignment.
+- **`Handlers/`**: Message handler pipeline (`SessionMessageHandler`, `CustomScriptMessageHandler`, `WriteUpMessageHandler`, `MediaMessageHandler`, `ProjectMessageHandler`).
 
 ### CtfDeck.Contracts
 
@@ -43,10 +44,12 @@ Binary protocol, DTOs, and protocol serializers/deserializers.
 - **`Models/Scripts/`**: CustomScript DTOs.
 - **`Models/WriteUps/`**: WriteUp DTOs (`WriteUpDto`, `WriteUpMetadataDto`).
 - **`Models/Media/`**: Media DTOs (`MediaDto`, `MediaMetadataDto`).
+- **`Models/Projects/`**: Project DTOs (`ProjectDto`, `ProjectMetadataDto`, `ProjectFolderDto`).
 - **`Protocols/Session/`**: Session protocol serializer/deserializer.
 - **`Protocols/CustomScript/`**: Custom script protocol serializer/deserializer.
 - **`Protocols/WriteUp/`**: Write-up protocol serializer/deserializer.
 - **`Protocols/Media/`**: Media protocol serializer/deserializer.
+- **`Protocols/Project/`**: Project protocol serializer/deserializer.
 
 ### CtfDeck.Abstractions
 
@@ -56,17 +59,19 @@ Port interfaces (hexagonal architecture).
 - **`Ports/Scripts/ICustomScriptRepository.cs`**
 - **`Ports/WriteUps/IWriteUpRepository.cs`**
 - **`Ports/Media/IMediaRepository.cs`**
+- **`Ports/Projects/IProjectRepository.cs`**
 
 ### CtfDeck.Data
 
 LiteDB persistence layer (adapter).
 
-- **`Db/CtfDeckDbContext.cs`**: LiteDB setup. Collections: `sessions`, `customscripts`, `writeups`, `media`.
-- **`PersistenceModels/`**: Persistence models for Sessions, Scripts, WriteUps, Media.
+- **`Db/CtfDeckDbContext.cs`**: LiteDB setup. Collections: `sessions`, `customscripts`, `writeups`, `media`, `projects`.
+- **`PersistenceModels/`**: Persistence models for Sessions, Scripts, WriteUps, Media, Projects.
 - **`Repositories/Sessions/`**: Implements `ISessionRepository`.
 - **`Repositories/Scripts/`**: Implements `ICustomScriptRepository`.
 - **`Repositories/WriteUps/`**: Implements `IWriteUpRepository`.
 - **`Repositories/Media/`**: Implements `IMediaRepository`.
+- **`Repositories/Projects/`**: Implements `IProjectRepository`.
 
 ---
 
@@ -77,6 +82,7 @@ LiteDB persistence layer (adapter).
   - **`WebSocket/`**: Tests for the binary protocol, connection handling, and integration.
   - **`WriteUp/`**: Tests for write-up protocol serialization/deserialization round-trips.
   - **`Media/`**: Tests for media protocol serialization/deserialization round-trips.
+  - **`Project/`**: Tests for project protocol serialization/deserialization round-trips.
 
 ---
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -109,11 +109,13 @@ All message types (1-byte prefix):
 | WriteUpDelete | 52 | Client → Server | Delete a write-up |
 | WriteUpList | 53 | Client → Server | List write-ups for a session |
 | WriteUpLoad | 54 | Client → Server | Load full write-up data |
+| WriteUpMove | 55 | Client → Server | Move write-up to a folder |
 | WriteUpCreateResult | 60 | Server → Client | Response to WriteUpCreate |
 | WriteUpUpdateResult | 61 | Server → Client | Response to WriteUpUpdate |
 | WriteUpDeleteResult | 62 | Server → Client | Response to WriteUpDelete |
 | WriteUpListResult | 63 | Server → Client | Response to WriteUpList |
 | WriteUpLoadResult | 64 | Server → Client | Response to WriteUpLoad |
+| WriteUpMoveResult | 65 | Server → Client | Response to WriteUpMove |
 | WriteUpOperationError | 69 | Server → Client | Write-up error response |
 | MediaUpload | 70 | Client → Server | Upload a media file |
 | MediaLoad | 71 | Client → Server | Load a media entry (with blob) |
@@ -124,6 +126,29 @@ All message types (1-byte prefix):
 | MediaDeleteResult | 82 | Server → Client | Response to MediaDelete |
 | MediaListResult | 83 | Server → Client | Response to MediaList |
 | MediaOperationError | 89 | Server → Client | Media error response |
+| ProjectCreate | 90 | Client → Server | Create a new project |
+| ProjectLoad | 91 | Client → Server | Load full project data |
+| ProjectList | 92 | Client → Server | List all projects (metadata) |
+| ProjectUpdate | 93 | Client → Server | Update project |
+| ProjectDelete | 94 | Client → Server | Delete a project |
+| ProjectAddFolder | 95 | Client → Server | Add folder to project |
+| ProjectDeleteFolder | 96 | Client → Server | Delete folder from project |
+| ProjectRenameFolder | 97 | Client → Server | Rename folder |
+| ProjectAssignSession | 98 | Client → Server | Assign session to project |
+| ProjectCreateResult | 100 | Server → Client | Response to ProjectCreate |
+| ProjectLoadResult | 101 | Server → Client | Response to ProjectLoad |
+| ProjectListResult | 102 | Server → Client | Response to ProjectList |
+| ProjectUpdateResult | 103 | Server → Client | Response to ProjectUpdate |
+| ProjectDeleteResult | 104 | Server → Client | Response to ProjectDelete |
+| ProjectAddFolderResult | 105 | Server → Client | Response to ProjectAddFolder |
+| ProjectDeleteFolderResult | 106 | Server → Client | Response to ProjectDeleteFolder |
+| ProjectRenameFolderResult | 107 | Server → Client | Response to ProjectRenameFolder |
+| ProjectAssignSessionResult | 108 | Server → Client | Response to ProjectAssignSession |
+| ProjectOperationError | 109 | Server → Client | Project error response |
+| ProjectListSessions | 110 | Client → Server | List sessions for a project |
+| ProjectListSessionsResult | 111 | Server → Client | Response to ProjectListSessions |
+| ProjectListWriteUps | 112 | Client → Server | List write-ups for a folder |
+| ProjectListWriteUpsResult | 113 | Server → Client | Response to ProjectListWriteUps |
 
 ## Error Codes
 
@@ -598,8 +623,9 @@ OFFSET | SIZE | TYPE      | DESCRIPTION
 24+N   | D    | bytes[]   | Description (UTF-8)
 24+N+D | 8    | int64     | CreatedAt (.NET ticks)
 32+N+D | 8    | int64     | UpdatedAt (.NET ticks)
-40+N+D | 4    | int32     | History count (H)
-44+N+D | ...  | Entry[]   | History entries
+40+N+D | 16   | bytes[16] | Project ID (UUID, Guid.Empty = no project)
+56+N+D | 4    | int32     | History count (H)
+60+N+D | ...  | Entry[]   | History entries
 ...    | 4    | int32     | Target count (T)
 ...    | ...  | Target[]  | Targets
 ```
@@ -639,6 +665,7 @@ OFFSET | SIZE | TYPE      | DESCRIPTION
 32+N+D | 8    | int64     | UpdatedAt (.NET ticks)
 40+N+D | 4    | int32     | History count
 44+N+D | 4    | int32     | Target count
+48+N+D | 16   | bytes[16] | Project ID (UUID, Guid.Empty = no project)
 ```
 
 #### SessionDeleteResult
@@ -939,6 +966,8 @@ The Write-Up Protocol extends the base protocol to support CTF write-ups (report
 | WriteUpDeleteResult | 62 | Server → Client | Response to WriteUpDelete |
 | WriteUpListResult | 63 | Server → Client | Response to WriteUpList |
 | WriteUpLoadResult | 64 | Server → Client | Response to WriteUpLoad |
+| WriteUpMove | 55 | Client → Server | Move write-up to a folder |
+| WriteUpMoveResult | 65 | Server → Client | Response to WriteUpMove |
 | WriteUpOperationError | 69 | Server → Client | Error response |
 
 ### Request Message Formats
@@ -989,6 +1018,17 @@ OFFSET | SIZE | TYPE      | DESCRIPTION
 17     | 16   | bytes[16] | Write-up ID (UUID)
 ```
 
+#### WriteUpMove
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (55)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Write-up ID (UUID)
+33     | 16   | bytes[16] | Folder ID (UUID, Guid.Empty to unlink)
+```
+
+**Note:** This message is routed through the Project message handler, not the WriteUp handler.
+
 ### Response Message Formats
 
 #### WriteUpCreateResult
@@ -1030,10 +1070,11 @@ OFFSET | SIZE | TYPE        | DESCRIPTION
 OFFSET | SIZE | TYPE      | DESCRIPTION
 0      | 16   | bytes[16] | Write-up ID (UUID)
 16     | 16   | bytes[16] | Session ID (UUID)
-32     | 4    | int32     | Name length (N)
-36     | N    | bytes[]   | Name (UTF-8)
-36+N   | 8    | int64     | CreatedAt (.NET ticks)
-44+N   | 8    | int64     | UpdatedAt (.NET ticks)
+32     | 16   | bytes[16] | Folder ID (UUID, Guid.Empty = no folder)
+48     | 4    | int32     | Name length (N)
+52     | N    | bytes[]   | Name (UTF-8)
+52+N   | 8    | int64     | CreatedAt (.NET ticks)
+60+N   | 8    | int64     | UpdatedAt (.NET ticks)
 ```
 
 #### WriteUpLoadResult
@@ -1050,12 +1091,21 @@ OFFSET | SIZE | TYPE      | DESCRIPTION
 OFFSET | SIZE | TYPE      | DESCRIPTION
 0      | 16   | bytes[16] | Write-up ID (UUID)
 16     | 16   | bytes[16] | Session ID (UUID)
-32     | 4    | int32     | Name length (N)
-36     | N    | bytes[]   | Name (UTF-8)
-36+N   | 4    | int32     | Content length (C)
-40+N   | C    | bytes[]   | Markdown content (UTF-8)
-40+N+C | 8    | int64     | CreatedAt (.NET ticks)
-48+N+C | 8    | int64     | UpdatedAt (.NET ticks)
+32     | 16   | bytes[16] | Folder ID (UUID, Guid.Empty = no folder)
+48     | 4    | int32     | Name length (N)
+52     | N    | bytes[]   | Name (UTF-8)
+52+N   | 4    | int32     | Content length (C)
+56+N   | C    | bytes[]   | Markdown content (UTF-8)
+56+N+C | 8    | int64     | CreatedAt (.NET ticks)
+64+N+C | 8    | int64     | UpdatedAt (.NET ticks)
+```
+
+#### WriteUpMoveResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (65)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
 ```
 
 #### WriteUpOperationError
@@ -1251,4 +1301,329 @@ Media entries are persisted using LiteDB:
 |-------|-------|------------|
 | File exceeds maximum upload size | Upload data > 8 MB | Reduce file size before uploading |
 | Media not found | Invalid media ID on load/delete | Use MediaList to get valid IDs |
+| Database locked | Concurrent access | Retry operation |
+
+---
+
+## Project Management Protocol
+
+### Overview
+
+The Project Management Protocol extends the base protocol to support organizing CTF work into projects. A Project groups sessions and write-up folders. Each project automatically gets a "Report" system folder on creation. Sessions link to projects via `ProjectId` and write-ups can be moved between folders via `FolderId`.
+
+**Key Features:**
+- Full CRUD for projects
+- Embedded folder management (add, delete, rename)
+- System folders (e.g., "Report") that cannot be deleted or renamed
+- Session-to-project assignment
+- Write-up-to-folder assignment
+- Content listing (sessions by project, write-ups by folder)
+- LiteDB persistence on server side
+
+### Message Types
+
+| Type | Value | Direction | Description |
+|------|-------|-----------|-------------|
+| ProjectCreate | 90 | Client → Server | Create a new project |
+| ProjectLoad | 91 | Client → Server | Load full project data |
+| ProjectList | 92 | Client → Server | List all projects (metadata) |
+| ProjectUpdate | 93 | Client → Server | Update project name and description |
+| ProjectDelete | 94 | Client → Server | Delete a project |
+| ProjectAddFolder | 95 | Client → Server | Add a folder to a project |
+| ProjectDeleteFolder | 96 | Client → Server | Delete a folder from a project |
+| ProjectRenameFolder | 97 | Client → Server | Rename a folder |
+| ProjectAssignSession | 98 | Client → Server | Assign/unlink a session to/from a project |
+| ProjectCreateResult | 100 | Server → Client | Response to ProjectCreate |
+| ProjectLoadResult | 101 | Server → Client | Response to ProjectLoad |
+| ProjectListResult | 102 | Server → Client | Response to ProjectList |
+| ProjectUpdateResult | 103 | Server → Client | Response to ProjectUpdate |
+| ProjectDeleteResult | 104 | Server → Client | Response to ProjectDelete |
+| ProjectAddFolderResult | 105 | Server → Client | Response to ProjectAddFolder |
+| ProjectDeleteFolderResult | 106 | Server → Client | Response to ProjectDeleteFolder |
+| ProjectRenameFolderResult | 107 | Server → Client | Response to ProjectRenameFolder |
+| ProjectAssignSessionResult | 108 | Server → Client | Response to ProjectAssignSession |
+| ProjectOperationError | 109 | Server → Client | Error response |
+| ProjectListSessions | 110 | Client → Server | List sessions for a project |
+| ProjectListSessionsResult | 111 | Server → Client | Response to ProjectListSessions |
+| ProjectListWriteUps | 112 | Client → Server | List write-ups for a folder |
+| ProjectListWriteUpsResult | 113 | Server → Client | Response to ProjectListWriteUps |
+
+### Request Message Formats
+
+#### ProjectCreate
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (90)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 4    | int32     | Name length (N)
+21     | N    | bytes[]   | Project name (UTF-8)
+21+N   | 4    | int32     | Description length (D)
+25+N   | D    | bytes[]   | Description (UTF-8)
+```
+
+#### ProjectLoad
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (91)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Project ID (UUID)
+```
+
+#### ProjectList
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (92)
+1      | 16   | bytes[16] | Message ID (UUID)
+```
+
+#### ProjectUpdate
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (93)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Project ID (UUID)
+33     | 4    | int32     | Name length (N)
+37     | N    | bytes[]   | Project name (UTF-8)
+37+N   | 4    | int32     | Description length (D)
+41+N   | D    | bytes[]   | Description (UTF-8)
+```
+
+#### ProjectDelete
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (94)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Project ID (UUID)
+```
+
+**Notes:**
+- Deleting a project orphans all linked sessions (`ProjectId` → null) and all write-ups in the project's folders (`FolderId` → null).
+
+#### ProjectAddFolder
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (95)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Project ID (UUID)
+33     | 4    | int32     | Name length (N)
+37     | N    | bytes[]   | Folder name (UTF-8)
+```
+
+#### ProjectDeleteFolder
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (96)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Project ID (UUID)
+33     | 16   | bytes[16] | Folder ID (UUID)
+```
+
+**Notes:**
+- System folders (e.g., "Report") cannot be deleted. The server returns `success = 0`.
+- Deleting a folder orphans all write-ups in that folder (`FolderId` → null).
+
+#### ProjectRenameFolder
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (97)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Project ID (UUID)
+33     | 16   | bytes[16] | Folder ID (UUID)
+49     | 4    | int32     | Name length (N)
+53     | N    | bytes[]   | New folder name (UTF-8)
+```
+
+**Notes:**
+- System folders cannot be renamed. The server returns `success = 0`.
+
+#### ProjectAssignSession
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (98)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Session ID (UUID)
+33     | 16   | bytes[16] | Project ID (UUID, Guid.Empty to unlink)
+```
+
+#### ProjectListSessions
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (110)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Project ID (UUID)
+```
+
+#### ProjectListWriteUps
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (112)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 16   | bytes[16] | Folder ID (UUID)
+```
+
+### Response Message Formats
+
+#### ProjectCreateResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (100)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+18     | 16   | bytes[16] | Created project ID (UUID)
+```
+
+#### ProjectLoadResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (101)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+18     | ...  | Project   | Project data (if success)
+```
+
+**Project structure:**
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 16   | bytes[16] | Project ID (UUID)
+16     | 4    | int32     | Name length (N)
+20     | N    | bytes[]   | Name (UTF-8)
+20+N   | 4    | int32     | Description length (D)
+24+N   | D    | bytes[]   | Description (UTF-8)
+24+N+D | 8    | int64     | CreatedAt (.NET ticks)
+32+N+D | 8    | int64     | UpdatedAt (.NET ticks)
+40+N+D | 4    | int32     | Folder count (F)
+44+N+D | ...  | Folder[]  | Folders
+```
+
+**ProjectFolder structure:**
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 16   | bytes[16] | Folder ID (UUID)
+16     | 4    | int32     | Name length (N)
+20     | N    | bytes[]   | Name (UTF-8)
+20+N   | 1    | byte      | IsSystem (1 = system folder, 0 = user folder)
+```
+
+#### ProjectListResult
+```
+OFFSET | SIZE | TYPE        | DESCRIPTION
+0      | 1    | byte        | Message type (102)
+1      | 16   | bytes[16]   | Message ID (UUID)
+17     | 4    | int32       | Project count (N)
+21     | ...  | Metadata[]  | Project metadata array
+```
+
+**ProjectMetadata structure:**
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 16   | bytes[16] | Project ID (UUID)
+16     | 4    | int32     | Name length (N)
+20     | N    | bytes[]   | Name (UTF-8)
+20+N   | 4    | int32     | Description length (D)
+24+N   | D    | bytes[]   | Description (UTF-8)
+24+N+D | 8    | int64     | CreatedAt (.NET ticks)
+32+N+D | 8    | int64     | UpdatedAt (.NET ticks)
+40+N+D | 4    | int32     | Folder count
+44+N+D | 4    | int32     | Session count
+```
+
+#### ProjectUpdateResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (103)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### ProjectDeleteResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (104)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### ProjectAddFolderResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (105)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+18     | 16   | bytes[16] | Created folder ID (UUID)
+```
+
+#### ProjectDeleteFolderResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (106)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### ProjectRenameFolderResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (107)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### ProjectAssignSessionResult
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (108)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 1    | byte      | Success (1 = true, 0 = false)
+```
+
+#### ProjectListSessionsResult
+```
+OFFSET | SIZE | TYPE        | DESCRIPTION
+0      | 1    | byte        | Message type (111)
+1      | 16   | bytes[16]   | Message ID (UUID)
+17     | 4    | int32       | Session count (N)
+21     | ...  | Metadata[]  | SessionMetadata entries (same format as SessionListResult)
+```
+
+#### ProjectListWriteUpsResult
+```
+OFFSET | SIZE | TYPE        | DESCRIPTION
+0      | 1    | byte        | Message type (113)
+1      | 16   | bytes[16]   | Message ID (UUID)
+17     | 4    | int32       | Write-up count (N)
+21     | ...  | Metadata[]  | WriteUpMetadata entries (same format as WriteUpListResult)
+```
+
+#### ProjectOperationError
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (109)
+1      | 16   | bytes[16] | Message ID (UUID)
+17     | 4    | int32     | Error length (E)
+21     | E    | bytes[]   | Error message (UTF-8)
+```
+
+### Storage
+
+Projects are persisted using LiteDB:
+- **Collection:** `projects`
+- **Indexes:** `Id` (unique), `Name`
+- Folders are embedded in the project document (not a separate collection)
+
+### Design Decisions
+
+- **"Report" folder**: Auto-created on project creation (`IsSystem = true`). Cannot be deleted or renamed.
+- **"Sessions" is virtual**: Sessions link to projects via `ProjectId`, no folder entity needed.
+- **Project delete**: Orphans sessions (`ProjectId` → null) and write-ups in all project folders (`FolderId` → null).
+- **Folder delete**: Orphans write-ups (`FolderId` → null).
+- **Backward compatible**: `ProjectId` and `FolderId` are nullable. Existing LiteDB documents get `null` automatically.
+
+### Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| Project not found | Invalid project ID | Use ProjectList to get valid IDs |
+| Cannot delete system folder | Attempted to delete "Report" | System folders are protected |
+| Cannot rename system folder | Attempted to rename "Report" | System folders are protected |
+| Session not found | Invalid session ID on assign | Use SessionList to get valid IDs |
 | Database locked | Concurrent access | Retry operation |

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -93,6 +93,7 @@ The test suite covers all protocol layers and terminal functionality:
 | `WebSocket/` | `BinaryProtocolTests.cs`, `OutputBatcherTests.cs`, `WebSocketServerTests.cs`, `WebSocketIntegrationTests.cs` | Binary protocol round-trips, batching, server lifecycle, real WebSocket connections |
 | `WriteUp/` | `WriteUpProtocolTests.cs` | Write-up protocol serialize/deserialize round-trips, unicode content, message type range |
 | `Media/` | `MediaProtocolTests.cs` | Media protocol serialize/deserialize round-trips, large binary data, message type range |
+| `Project/` | `ProjectProtocolTests.cs` | Project protocol serialize/deserialize round-trips, folder operations, message type range |
 
 ## Continuous Integration
 

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -50,18 +50,18 @@ dotnet build
 
 ### Running the server
 
-The main application is located in `src/CtfDeck.Terminal/`.
+The main application is located in `src/CtfDeck.ServerWs/`.
 
 #### Using the .NET CLI
 
 From the root directory:
 ```bash
-dotnet run --project src/CtfDeck.Terminal/
+dotnet run --project src/CtfDeck.ServerWs/
 ```
 
 #### Using Visual Studio
 1. Open `CtfDeck.sln`.
-2. Set `CtfDeck.Terminal` as the startup project.
+2. Set `CtfDeck.ServerWs` as the startup project.
 3. Press `F5` to start.
 
 The server will start and listen for WebSocket connections on port `42712` by default.

--- a/src/CtfDeck.Abstractions/Ports/Projects/IProjectRepository.cs
+++ b/src/CtfDeck.Abstractions/Ports/Projects/IProjectRepository.cs
@@ -1,0 +1,16 @@
+using CtfDeck.Contracts.Models.Projects;
+
+namespace CtfDeck.Abstractions.Ports.Projects;
+
+public interface IProjectRepository
+{
+    ProjectDto Create(string name, string description);
+    ProjectDto? GetById(Guid id);
+    IEnumerable<ProjectMetadataDto> GetAllMetadata();
+    bool Update(Guid id, string name, string description);
+    bool Delete(Guid id);
+    ProjectFolderDto? AddFolder(Guid projectId, string name);
+    bool DeleteFolder(Guid projectId, Guid folderId);
+    bool RenameFolder(Guid projectId, Guid folderId, string name);
+    List<Guid> GetFolderIds(Guid projectId);
+}

--- a/src/CtfDeck.Abstractions/Ports/Sessions/ISessionRepository.cs
+++ b/src/CtfDeck.Abstractions/Ports/Sessions/ISessionRepository.cs
@@ -16,4 +16,8 @@ public interface ISessionRepository
     SessionTargetDto? AddTarget(Guid sessionId, SessionTargetDto target);
     bool DeleteTarget(Guid sessionId, Guid targetId);
     bool UpdateTarget(Guid sessionId, SessionTargetDto target);
+
+    IEnumerable<SessionMetadataDto> GetByProjectId(Guid projectId);
+    bool SetProjectId(Guid sessionId, Guid? projectId);
+    void ClearProjectId(Guid projectId);
 }

--- a/src/CtfDeck.Abstractions/Ports/WriteUps/IWriteUpRepository.cs
+++ b/src/CtfDeck.Abstractions/Ports/WriteUps/IWriteUpRepository.cs
@@ -9,4 +9,8 @@ public interface IWriteUpRepository
     List<WriteUpMetadataDto> GetBySessionId(Guid sessionId);
     bool Update(Guid id, string name, string content);
     bool Delete(Guid id);
+
+    List<WriteUpMetadataDto> GetByFolderId(Guid folderId);
+    bool SetFolderId(Guid writeUpId, Guid? folderId);
+    void ClearFolderId(Guid folderId);
 }

--- a/src/CtfDeck.Contracts/Models/Projects/ProjectDto.cs
+++ b/src/CtfDeck.Contracts/Models/Projects/ProjectDto.cs
@@ -1,13 +1,11 @@
-namespace CtfDeck.Contracts.Models.Sessions;
+namespace CtfDeck.Contracts.Models.Projects;
 
-public sealed class SessionMetadataDto
+public sealed class ProjectDto
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
-    public int HistoryCount { get; set; }
-    public int TargetCount { get; set; }
-    public Guid? ProjectId { get; set; }
+    public List<ProjectFolderDto> Folders { get; set; } = new();
 }

--- a/src/CtfDeck.Contracts/Models/Projects/ProjectFolderDto.cs
+++ b/src/CtfDeck.Contracts/Models/Projects/ProjectFolderDto.cs
@@ -1,0 +1,8 @@
+namespace CtfDeck.Contracts.Models.Projects;
+
+public sealed class ProjectFolderDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsSystem { get; set; }
+}

--- a/src/CtfDeck.Contracts/Models/Projects/ProjectMetadataDto.cs
+++ b/src/CtfDeck.Contracts/Models/Projects/ProjectMetadataDto.cs
@@ -1,13 +1,12 @@
-namespace CtfDeck.Contracts.Models.Sessions;
+namespace CtfDeck.Contracts.Models.Projects;
 
-public sealed class SessionMetadataDto
+public sealed class ProjectMetadataDto
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
-    public int HistoryCount { get; set; }
-    public int TargetCount { get; set; }
-    public Guid? ProjectId { get; set; }
+    public int FolderCount { get; set; }
+    public int SessionCount { get; set; }
 }

--- a/src/CtfDeck.Contracts/Models/Sessions/SessionDto.cs
+++ b/src/CtfDeck.Contracts/Models/Sessions/SessionDto.cs
@@ -7,6 +7,7 @@ public sealed class SessionDto
     public string Description { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
+    public Guid? ProjectId { get; set; }
     public List<HistoryEntryDto> History { get; set; } = new();
     public List<SessionTargetDto> Targets { get; set; } = new();
 }

--- a/src/CtfDeck.Contracts/Models/WriteUps/WriteUpDto.cs
+++ b/src/CtfDeck.Contracts/Models/WriteUps/WriteUpDto.cs
@@ -4,6 +4,7 @@ public sealed class WriteUpDto
 {
     public Guid Id { get; set; }
     public Guid SessionId { get; set; }
+    public Guid? FolderId { get; set; }
     public string Name { get; set; } = "";
     public string Content { get; set; } = "";
     public DateTime CreatedAt { get; set; }

--- a/src/CtfDeck.Contracts/Models/WriteUps/WriteUpMetadataDto.cs
+++ b/src/CtfDeck.Contracts/Models/WriteUps/WriteUpMetadataDto.cs
@@ -4,6 +4,7 @@ public sealed class WriteUpMetadataDto
 {
     public Guid Id { get; set; }
     public Guid SessionId { get; set; }
+    public Guid? FolderId { get; set; }
     public string Name { get; set; } = "";
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }

--- a/src/CtfDeck.Contracts/Protocols/Project/ProjectProtocolDeserializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/Project/ProjectProtocolDeserializer.cs
@@ -1,0 +1,210 @@
+using System.Text;
+using CtfDeck.Contracts.Transport;
+
+namespace CtfDeck.Contracts.Protocols.Project;
+
+public readonly ref struct ProjectCreateRequest
+{
+    public readonly Guid MessageId;
+    public readonly string Name;
+    public readonly string Description;
+
+    public ProjectCreateRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][4B nameLen][name][4B descLen][desc]
+        MessageId = new Guid(data.Slice(1, 16));
+
+        var offset = 17;
+        var nameLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Name = Encoding.UTF8.GetString(data.Slice(offset, nameLen));
+        offset += nameLen;
+
+        var descLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Description = Encoding.UTF8.GetString(data.Slice(offset, descLen));
+    }
+}
+
+public readonly ref struct ProjectLoadRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid ProjectId;
+
+    public ProjectLoadRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B projectId]
+        MessageId = new Guid(data.Slice(1, 16));
+        ProjectId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public readonly ref struct ProjectListRequest
+{
+    public readonly Guid MessageId;
+
+    public ProjectListRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId]
+        MessageId = new Guid(data.Slice(1, 16));
+    }
+}
+
+public class ProjectUpdateRequest
+{
+    public Guid MessageId { get; }
+    public Guid ProjectId { get; }
+    public string Name { get; }
+    public string Description { get; }
+
+    public ProjectUpdateRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B projectId][4B nameLen][name][4B descLen][desc]
+        MessageId = new Guid(data.Slice(1, 16));
+        ProjectId = new Guid(data.Slice(17, 16));
+
+        var offset = 33;
+        var nameLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Name = Encoding.UTF8.GetString(data.Slice(offset, nameLen));
+        offset += nameLen;
+
+        var descLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Description = Encoding.UTF8.GetString(data.Slice(offset, descLen));
+    }
+}
+
+public readonly ref struct ProjectDeleteRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid ProjectId;
+
+    public ProjectDeleteRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B projectId]
+        MessageId = new Guid(data.Slice(1, 16));
+        ProjectId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public class ProjectAddFolderRequest
+{
+    public Guid MessageId { get; }
+    public Guid ProjectId { get; }
+    public string Name { get; }
+
+    public ProjectAddFolderRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B projectId][4B nameLen][name]
+        MessageId = new Guid(data.Slice(1, 16));
+        ProjectId = new Guid(data.Slice(17, 16));
+
+        var offset = 33;
+        var nameLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Name = Encoding.UTF8.GetString(data.Slice(offset, nameLen));
+    }
+}
+
+public readonly ref struct ProjectDeleteFolderRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid ProjectId;
+    public readonly Guid FolderId;
+
+    public ProjectDeleteFolderRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B projectId][16B folderId]
+        MessageId = new Guid(data.Slice(1, 16));
+        ProjectId = new Guid(data.Slice(17, 16));
+        FolderId = new Guid(data.Slice(33, 16));
+    }
+}
+
+public class ProjectRenameFolderRequest
+{
+    public Guid MessageId { get; }
+    public Guid ProjectId { get; }
+    public Guid FolderId { get; }
+    public string Name { get; }
+
+    public ProjectRenameFolderRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B projectId][16B folderId][4B nameLen][name]
+        MessageId = new Guid(data.Slice(1, 16));
+        ProjectId = new Guid(data.Slice(17, 16));
+        FolderId = new Guid(data.Slice(33, 16));
+
+        var offset = 49;
+        var nameLen = BitConverter.ToInt32(data.Slice(offset, 4));
+        offset += 4;
+        Name = Encoding.UTF8.GetString(data.Slice(offset, nameLen));
+    }
+}
+
+public readonly ref struct ProjectAssignSessionRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid SessionId;
+    public readonly Guid ProjectId;
+
+    public ProjectAssignSessionRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B sessionId][16B projectId]
+        MessageId = new Guid(data.Slice(1, 16));
+        SessionId = new Guid(data.Slice(17, 16));
+        ProjectId = new Guid(data.Slice(33, 16));
+    }
+}
+
+public readonly ref struct WriteUpMoveRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid WriteUpId;
+    public readonly Guid FolderId;
+
+    public WriteUpMoveRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B writeUpId][16B folderId]
+        MessageId = new Guid(data.Slice(1, 16));
+        WriteUpId = new Guid(data.Slice(17, 16));
+        FolderId = new Guid(data.Slice(33, 16));
+    }
+}
+
+public readonly ref struct ProjectListSessionsRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid ProjectId;
+
+    public ProjectListSessionsRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B projectId]
+        MessageId = new Guid(data.Slice(1, 16));
+        ProjectId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public readonly ref struct ProjectListWriteUpsRequest
+{
+    public readonly Guid MessageId;
+    public readonly Guid FolderId;
+
+    public ProjectListWriteUpsRequest(ReadOnlySpan<byte> data)
+    {
+        // Format: [1B type][16B msgId][16B folderId]
+        MessageId = new Guid(data.Slice(1, 16));
+        FolderId = new Guid(data.Slice(17, 16));
+    }
+}
+
+public static class ProjectProtocolDeserializer
+{
+    public static bool IsProjectMessage(MessageType type)
+    {
+        return (type >= MessageType.ProjectCreate && type <= MessageType.ProjectAssignSession)
+            || type == MessageType.WriteUpMove
+            || (type >= MessageType.ProjectListSessions && type <= MessageType.ProjectListWriteUps);
+    }
+}

--- a/src/CtfDeck.Contracts/Protocols/Project/ProjectProtocolSerializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/Project/ProjectProtocolSerializer.cs
@@ -1,0 +1,167 @@
+using CtfDeck.Contracts.Models.Projects;
+using CtfDeck.Contracts.Models.Sessions;
+using CtfDeck.Contracts.Models.WriteUps;
+using CtfDeck.Contracts.Transport;
+
+namespace CtfDeck.Contracts.Protocols.Project;
+
+public static class ProjectProtocolSerializer
+{
+    public static byte[] SerializeCreateResult(Guid messageId, bool success, Guid projectId)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectCreateResult);
+        writer.WriteGuid(messageId);
+        writer.WriteByte((byte)(success ? 1 : 0));
+        writer.WriteGuid(projectId);
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeLoadResult(Guid messageId, bool success, ProjectDto? project)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectLoadResult);
+        writer.WriteGuid(messageId);
+        writer.WriteByte((byte)(success ? 1 : 0));
+
+        if (success && project != null)
+        {
+            WriteProject(writer, project);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeListResult(Guid messageId, IEnumerable<ProjectMetadataDto> projects)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectListResult);
+        writer.WriteGuid(messageId);
+
+        var list = projects.ToList();
+        writer.WriteInt32(list.Count);
+
+        foreach (var meta in list)
+        {
+            WriteProjectMetadata(writer, meta);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeUpdateResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.ProjectUpdateResult, messageId, success);
+
+    public static byte[] SerializeDeleteResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.ProjectDeleteResult, messageId, success);
+
+    public static byte[] SerializeAddFolderResult(Guid messageId, bool success, Guid folderId)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectAddFolderResult);
+        writer.WriteGuid(messageId);
+        writer.WriteByte((byte)(success ? 1 : 0));
+        writer.WriteGuid(folderId);
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeDeleteFolderResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.ProjectDeleteFolderResult, messageId, success);
+
+    public static byte[] SerializeRenameFolderResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.ProjectRenameFolderResult, messageId, success);
+
+    public static byte[] SerializeAssignSessionResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.ProjectAssignSessionResult, messageId, success);
+
+    public static byte[] SerializeWriteUpMoveResult(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.WriteUpMoveResult, messageId, success);
+
+    public static byte[] SerializeListSessionsResult(Guid messageId, List<SessionMetadataDto> sessions)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectListSessionsResult);
+        writer.WriteGuid(messageId);
+        writer.WriteInt32(sessions.Count);
+
+        foreach (var meta in sessions)
+        {
+            WriteSessionMetadata(writer, meta);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeListWriteUpsResult(Guid messageId, List<WriteUpMetadataDto> writeUps)
+    {
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectListWriteUpsResult);
+        writer.WriteGuid(messageId);
+        writer.WriteInt32(writeUps.Count);
+
+        foreach (var writeUp in writeUps)
+        {
+            WriteWriteUpMetadata(writer, writeUp);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static byte[] SerializeError(Guid messageId, string error)
+        => BinaryProtocolSerializer.SerializeError(MessageType.ProjectOperationError, messageId, error);
+
+    private static void WriteProject(PooledBufferWriter writer, ProjectDto project)
+    {
+        writer.WriteGuid(project.Id);
+        writer.WriteString(project.Name ?? string.Empty);
+        writer.WriteString(project.Description ?? string.Empty);
+        writer.WriteInt64(project.CreatedAt.Ticks);
+        writer.WriteInt64(project.UpdatedAt.Ticks);
+
+        writer.WriteInt32(project.Folders.Count);
+        foreach (var folder in project.Folders)
+        {
+            WriteProjectFolder(writer, folder);
+        }
+    }
+
+    private static void WriteProjectFolder(PooledBufferWriter writer, ProjectFolderDto folder)
+    {
+        writer.WriteGuid(folder.Id);
+        writer.WriteString(folder.Name ?? string.Empty);
+        writer.WriteByte((byte)(folder.IsSystem ? 1 : 0));
+    }
+
+    private static void WriteSessionMetadata(PooledBufferWriter writer, SessionMetadataDto meta)
+    {
+        writer.WriteGuid(meta.Id);
+        writer.WriteString(meta.Name);
+        writer.WriteString(meta.Description ?? string.Empty);
+        writer.WriteInt64(meta.CreatedAt.Ticks);
+        writer.WriteInt64(meta.UpdatedAt.Ticks);
+        writer.WriteInt32(meta.HistoryCount);
+        writer.WriteInt32(meta.TargetCount);
+        writer.WriteGuid(meta.ProjectId ?? Guid.Empty);
+    }
+
+    private static void WriteWriteUpMetadata(PooledBufferWriter writer, WriteUpMetadataDto writeUp)
+    {
+        writer.WriteGuid(writeUp.Id);
+        writer.WriteGuid(writeUp.SessionId);
+        writer.WriteGuid(writeUp.FolderId ?? Guid.Empty);
+        writer.WriteString(writeUp.Name);
+        writer.WriteInt64(writeUp.CreatedAt.Ticks);
+        writer.WriteInt64(writeUp.UpdatedAt.Ticks);
+    }
+
+    private static void WriteProjectMetadata(PooledBufferWriter writer, ProjectMetadataDto meta)
+    {
+        writer.WriteGuid(meta.Id);
+        writer.WriteString(meta.Name ?? string.Empty);
+        writer.WriteString(meta.Description ?? string.Empty);
+        writer.WriteInt64(meta.CreatedAt.Ticks);
+        writer.WriteInt64(meta.UpdatedAt.Ticks);
+        writer.WriteInt32(meta.FolderCount);
+        writer.WriteInt32(meta.SessionCount);
+    }
+}

--- a/src/CtfDeck.Contracts/Protocols/Session/SessionProtocolSerializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/Session/SessionProtocolSerializer.cs
@@ -82,6 +82,7 @@ public static class SessionProtocolSerializer
         writer.WriteString(session.Description ?? string.Empty);
         writer.WriteInt64(session.CreatedAt.Ticks);
         writer.WriteInt64(session.UpdatedAt.Ticks);
+        writer.WriteGuid(session.ProjectId ?? Guid.Empty);
 
         writer.WriteInt32(session.History.Count);
         foreach (var entry in session.History)
@@ -125,5 +126,6 @@ public static class SessionProtocolSerializer
         writer.WriteInt64(meta.UpdatedAt.Ticks);
         writer.WriteInt32(meta.HistoryCount);
         writer.WriteInt32(meta.TargetCount);
+        writer.WriteGuid(meta.ProjectId ?? Guid.Empty);
     }
 }

--- a/src/CtfDeck.Contracts/Protocols/WriteUp/WriteUpProtocolSerializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/WriteUp/WriteUpProtocolSerializer.cs
@@ -47,6 +47,7 @@ public static class WriteUpProtocolSerializer
         {
             writer.WriteGuid(writeUp.Id);
             writer.WriteGuid(writeUp.SessionId);
+            writer.WriteGuid(writeUp.FolderId ?? Guid.Empty);
             writer.WriteString(writeUp.Name);
             writer.WriteString(writeUp.Content);
             writer.WriteInt64(writeUp.CreatedAt.Ticks);
@@ -63,6 +64,7 @@ public static class WriteUpProtocolSerializer
     {
         writer.WriteGuid(writeUp.Id);
         writer.WriteGuid(writeUp.SessionId);
+        writer.WriteGuid(writeUp.FolderId ?? Guid.Empty);
         writer.WriteString(writeUp.Name);
         writer.WriteInt64(writeUp.CreatedAt.Ticks);
         writer.WriteInt64(writeUp.UpdatedAt.Ticks);

--- a/src/CtfDeck.Contracts/Transport/BinaryProtocol.cs
+++ b/src/CtfDeck.Contracts/Transport/BinaryProtocol.cs
@@ -62,6 +62,7 @@ public enum MessageType : byte
     WriteUpDelete = 52,
     WriteUpList = 53,
     WriteUpLoad = 54,
+    WriteUpMove = 55,
 
     // WriteUp responses (server → client)
     WriteUpCreateResult = 60,
@@ -69,6 +70,7 @@ public enum MessageType : byte
     WriteUpDeleteResult = 62,
     WriteUpListResult = 63,
     WriteUpLoadResult = 64,
+    WriteUpMoveResult = 65,
     WriteUpOperationError = 69,
 
     // Media requests (client → server)
@@ -82,7 +84,38 @@ public enum MessageType : byte
     MediaLoadResult = 81,
     MediaDeleteResult = 82,
     MediaListResult = 83,
-    MediaOperationError = 89
+    MediaOperationError = 89,
+
+    // Project requests (client → server)
+    ProjectCreate = 90,
+    ProjectLoad = 91,
+    ProjectList = 92,
+    ProjectUpdate = 93,
+    ProjectDelete = 94,
+    ProjectAddFolder = 95,
+    ProjectDeleteFolder = 96,
+    ProjectRenameFolder = 97,
+    ProjectAssignSession = 98,
+
+    // Project responses (server → client)
+    ProjectCreateResult = 100,
+    ProjectLoadResult = 101,
+    ProjectListResult = 102,
+    ProjectUpdateResult = 103,
+    ProjectDeleteResult = 104,
+    ProjectAddFolderResult = 105,
+    ProjectDeleteFolderResult = 106,
+    ProjectRenameFolderResult = 107,
+    ProjectAssignSessionResult = 108,
+    ProjectOperationError = 109,
+
+    // Project content queries (client → server)
+    ProjectListSessions = 110,
+    ProjectListWriteUps = 112,
+
+    // Project content responses (server → client)
+    ProjectListSessionsResult = 111,
+    ProjectListWriteUpsResult = 113
 }
 
 /// <summary>

--- a/src/CtfDeck.Data/Db/CtfDeckDbContext.cs
+++ b/src/CtfDeck.Data/Db/CtfDeckDbContext.cs
@@ -3,6 +3,7 @@ using CtfDeck.Data.PersistenceModels.Sessions;
 using CtfDeck.Data.PersistenceModels.Scripts;
 using CtfDeck.Data.PersistenceModels.WriteUps;
 using CtfDeck.Data.PersistenceModels.Media;
+using CtfDeck.Data.PersistenceModels.Projects;
 
 namespace CtfDeck.Data.Db;
 
@@ -16,6 +17,7 @@ public sealed class CtfDeckDbContext : IDisposable
     private readonly ILiteCollection<CustomScript> _customScripts;
     private readonly ILiteCollection<WriteUp> _writeUps;
     private readonly ILiteCollection<PersistenceModels.Media.Media> _media;
+    private readonly ILiteCollection<Project> _projects;
     private bool _disposed;
 
     public CtfDeckDbContext(string? databasePath = null)
@@ -43,12 +45,20 @@ public sealed class CtfDeckDbContext : IDisposable
         _media = _database.GetCollection<PersistenceModels.Media.Media>("media");
         _media.EnsureIndex(x => x.Id, unique: true);
         _media.EnsureIndex(x => x.FileName);
+
+        _projects = _database.GetCollection<Project>("projects");
+        _projects.EnsureIndex(x => x.Id, unique: true);
+        _projects.EnsureIndex(x => x.Name);
+
+        _sessions.EnsureIndex(x => x.ProjectId);
+        _writeUps.EnsureIndex(x => x.FolderId);
     }
 
     public ILiteCollection<Session> Sessions => _sessions;
     public ILiteCollection<CustomScript> CustomScripts => _customScripts;
     public ILiteCollection<WriteUp> WriteUps => _writeUps;
     public ILiteCollection<PersistenceModels.Media.Media> Media => _media;
+    public ILiteCollection<Project> Projects => _projects;
 
     private static void ConfigureBsonMapper()
     {
@@ -66,6 +76,8 @@ public sealed class CtfDeckDbContext : IDisposable
             BsonMapper.Global.Entity<CustomScript>().Id(x => x.Id);
             BsonMapper.Global.Entity<WriteUp>().Id(x => x.Id);
             BsonMapper.Global.Entity<PersistenceModels.Media.Media>().Id(x => x.Id);
+            BsonMapper.Global.Entity<Project>().Id(x => x.Id);
+            BsonMapper.Global.Entity<ProjectFolder>().Id(x => x.Id);
 
             _mapperConfigured = true;
         }

--- a/src/CtfDeck.Data/PersistenceModels/Projects/Project.cs
+++ b/src/CtfDeck.Data/PersistenceModels/Projects/Project.cs
@@ -1,13 +1,11 @@
-namespace CtfDeck.Contracts.Models.Sessions;
+namespace CtfDeck.Data.PersistenceModels.Projects;
 
-public sealed class SessionMetadataDto
+public class Project
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
-    public int HistoryCount { get; set; }
-    public int TargetCount { get; set; }
-    public Guid? ProjectId { get; set; }
+    public List<ProjectFolder> Folders { get; set; } = new();
 }

--- a/src/CtfDeck.Data/PersistenceModels/Projects/ProjectFolder.cs
+++ b/src/CtfDeck.Data/PersistenceModels/Projects/ProjectFolder.cs
@@ -1,0 +1,8 @@
+namespace CtfDeck.Data.PersistenceModels.Projects;
+
+public class ProjectFolder
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsSystem { get; set; }
+}

--- a/src/CtfDeck.Data/PersistenceModels/Sessions/Session.cs
+++ b/src/CtfDeck.Data/PersistenceModels/Sessions/Session.cs
@@ -7,6 +7,7 @@ public class Session
     public string Description { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
+    public Guid? ProjectId { get; set; }
     public List<HistoryEntry> History { get; set; } = new();
     public List<SessionTarget> Targets { get; set; } = new();
 }

--- a/src/CtfDeck.Data/PersistenceModels/WriteUps/WriteUp.cs
+++ b/src/CtfDeck.Data/PersistenceModels/WriteUps/WriteUp.cs
@@ -4,6 +4,7 @@ public class WriteUp
 {
     public Guid Id { get; set; }
     public Guid SessionId { get; set; }
+    public Guid? FolderId { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }

--- a/src/CtfDeck.Data/Repositories/Projects/ProjectRepository.cs
+++ b/src/CtfDeck.Data/Repositories/Projects/ProjectRepository.cs
@@ -1,0 +1,192 @@
+using CtfDeck.Abstractions.Ports.Projects;
+using CtfDeck.Contracts.Models.Projects;
+using CtfDeck.Data.Db;
+using CtfDeck.Data.PersistenceModels.Projects;
+
+namespace CtfDeck.Data.Repositories.Projects;
+
+public sealed class ProjectRepository : IProjectRepository
+{
+    private readonly CtfDeckDbContext _context;
+    private readonly object _lock = new();
+
+    public ProjectRepository(CtfDeckDbContext context)
+    {
+        _context = context;
+    }
+
+    public ProjectDto Create(string name, string description)
+    {
+        var now = DateTime.UtcNow;
+        var model = new Project
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Description = description,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Folders = new List<ProjectFolder>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Report",
+                    IsSystem = true
+                }
+            }
+        };
+
+        lock (_lock)
+        {
+            _context.Projects.Insert(model);
+        }
+
+        return ToDto(model);
+    }
+
+    public ProjectDto? GetById(Guid id)
+    {
+        lock (_lock)
+        {
+            var model = _context.Projects.FindById(id);
+            return model == null ? null : ToDto(model);
+        }
+    }
+
+    public IEnumerable<ProjectMetadataDto> GetAllMetadata()
+    {
+        lock (_lock)
+        {
+            return _context.Projects
+                .FindAll()
+                .Select(p => new ProjectMetadataDto
+                {
+                    Id = p.Id,
+                    Name = p.Name ?? "",
+                    Description = p.Description ?? "",
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    FolderCount = p.Folders?.Count ?? 0
+                })
+                .ToList();
+        }
+    }
+
+    public bool Update(Guid id, string name, string description)
+    {
+        lock (_lock)
+        {
+            var model = _context.Projects.FindById(id);
+            if (model == null) return false;
+
+            model.Name = name;
+            model.Description = description;
+            model.UpdatedAt = DateTime.UtcNow;
+
+            return _context.Projects.Update(model);
+        }
+    }
+
+    public bool Delete(Guid id)
+    {
+        lock (_lock)
+        {
+            return _context.Projects.Delete(id);
+        }
+    }
+
+    public ProjectFolderDto? AddFolder(Guid projectId, string name)
+    {
+        lock (_lock)
+        {
+            var model = _context.Projects.FindById(projectId);
+            if (model == null) return null;
+
+            var folder = new ProjectFolder
+            {
+                Id = Guid.NewGuid(),
+                Name = name,
+                IsSystem = false
+            };
+
+            model.Folders ??= new List<ProjectFolder>();
+            model.Folders.Add(folder);
+            model.UpdatedAt = DateTime.UtcNow;
+
+            _context.Projects.Update(model);
+
+            return new ProjectFolderDto
+            {
+                Id = folder.Id,
+                Name = folder.Name,
+                IsSystem = folder.IsSystem
+            };
+        }
+    }
+
+    public bool DeleteFolder(Guid projectId, Guid folderId)
+    {
+        lock (_lock)
+        {
+            var model = _context.Projects.FindById(projectId);
+            if (model == null) return false;
+
+            model.Folders ??= new List<ProjectFolder>();
+            var folder = model.Folders.Find(f => f.Id == folderId);
+            if (folder == null) return false;
+            if (folder.IsSystem) return false;
+
+            model.Folders.Remove(folder);
+            model.UpdatedAt = DateTime.UtcNow;
+
+            return _context.Projects.Update(model);
+        }
+    }
+
+    public bool RenameFolder(Guid projectId, Guid folderId, string name)
+    {
+        lock (_lock)
+        {
+            var model = _context.Projects.FindById(projectId);
+            if (model == null) return false;
+
+            model.Folders ??= new List<ProjectFolder>();
+            var folder = model.Folders.Find(f => f.Id == folderId);
+            if (folder == null) return false;
+            if (folder.IsSystem) return false;
+
+            folder.Name = name;
+            model.UpdatedAt = DateTime.UtcNow;
+
+            return _context.Projects.Update(model);
+        }
+    }
+
+    public List<Guid> GetFolderIds(Guid projectId)
+    {
+        lock (_lock)
+        {
+            var model = _context.Projects.FindById(projectId);
+            if (model == null) return new List<Guid>();
+
+            return (model.Folders ?? new List<ProjectFolder>())
+                .Select(f => f.Id)
+                .ToList();
+        }
+    }
+
+    private static ProjectDto ToDto(Project p) => new()
+    {
+        Id = p.Id,
+        Name = p.Name ?? "",
+        Description = p.Description ?? "",
+        CreatedAt = p.CreatedAt,
+        UpdatedAt = p.UpdatedAt,
+        Folders = (p.Folders ?? new List<ProjectFolder>()).Select(f => new ProjectFolderDto
+        {
+            Id = f.Id,
+            Name = f.Name ?? "",
+            IsSystem = f.IsSystem
+        }).ToList()
+    };
+}

--- a/src/CtfDeck.Data/Repositories/Sessions/SessionRepository.cs
+++ b/src/CtfDeck.Data/Repositories/Sessions/SessionRepository.cs
@@ -58,7 +58,8 @@ public sealed class SessionRepository : ISessionRepository
                     CreatedAt = s.CreatedAt,
                     UpdatedAt = s.UpdatedAt,
                     HistoryCount = s.History?.Count ?? 0,
-                    TargetCount = s.Targets?.Count ?? 0
+                    TargetCount = s.Targets?.Count ?? 0,
+                    ProjectId = s.ProjectId
                 })
                 .ToList();
         }
@@ -184,6 +185,54 @@ public sealed class SessionRepository : ISessionRepository
         }
     }
 
+    public IEnumerable<SessionMetadataDto> GetByProjectId(Guid projectId)
+    {
+        lock (_lock)
+        {
+            return _context.Sessions
+                .Find(s => s.ProjectId == projectId)
+                .Select(s => new SessionMetadataDto
+                {
+                    Id = s.Id,
+                    Name = s.Name,
+                    Description = s.Description,
+                    CreatedAt = s.CreatedAt,
+                    UpdatedAt = s.UpdatedAt,
+                    HistoryCount = s.History?.Count ?? 0,
+                    TargetCount = s.Targets?.Count ?? 0,
+                    ProjectId = s.ProjectId
+                })
+                .ToList();
+        }
+    }
+
+    public bool SetProjectId(Guid sessionId, Guid? projectId)
+    {
+        lock (_lock)
+        {
+            var model = _context.Sessions.FindById(sessionId);
+            if (model == null) return false;
+
+            model.ProjectId = projectId;
+            model.UpdatedAt = DateTime.UtcNow;
+
+            return _context.Sessions.Update(model);
+        }
+    }
+
+    public void ClearProjectId(Guid projectId)
+    {
+        lock (_lock)
+        {
+            var sessions = _context.Sessions.Find(s => s.ProjectId == projectId).ToList();
+            foreach (var session in sessions)
+            {
+                session.ProjectId = null;
+                _context.Sessions.Update(session);
+            }
+        }
+    }
+
     private static SessionDto ToDto(Session s) => new()
     {
         Id = s.Id,
@@ -191,6 +240,7 @@ public sealed class SessionRepository : ISessionRepository
         Description = s.Description,
         CreatedAt = s.CreatedAt,
         UpdatedAt = s.UpdatedAt,
+        ProjectId = s.ProjectId,
         History = (s.History ?? new List<HistoryEntry>()).Select(h => new HistoryEntryDto
         {
             Id = h.Id,

--- a/src/CtfDeck.Data/Repositories/WriteUps/WriteUpRepository.cs
+++ b/src/CtfDeck.Data/Repositories/WriteUps/WriteUpRepository.cs
@@ -79,10 +79,49 @@ public sealed class WriteUpRepository : IWriteUpRepository
         }
     }
 
+    public List<WriteUpMetadataDto> GetByFolderId(Guid folderId)
+    {
+        lock (_lock)
+        {
+            return _context.WriteUps
+                .Find(w => w.FolderId == folderId)
+                .Select(ToMetadataDto)
+                .ToList();
+        }
+    }
+
+    public bool SetFolderId(Guid writeUpId, Guid? folderId)
+    {
+        lock (_lock)
+        {
+            var model = _context.WriteUps.FindById(writeUpId);
+            if (model == null) return false;
+
+            model.FolderId = folderId;
+            model.UpdatedAt = DateTime.UtcNow;
+
+            return _context.WriteUps.Update(model);
+        }
+    }
+
+    public void ClearFolderId(Guid folderId)
+    {
+        lock (_lock)
+        {
+            var writeUps = _context.WriteUps.Find(w => w.FolderId == folderId).ToList();
+            foreach (var writeUp in writeUps)
+            {
+                writeUp.FolderId = null;
+                _context.WriteUps.Update(writeUp);
+            }
+        }
+    }
+
     private static WriteUpDto ToDto(WriteUp m) => new()
     {
         Id = m.Id,
         SessionId = m.SessionId,
+        FolderId = m.FolderId,
         Name = m.Name ?? "",
         Content = m.Content ?? "",
         CreatedAt = m.CreatedAt,
@@ -93,6 +132,7 @@ public sealed class WriteUpRepository : IWriteUpRepository
     {
         Id = m.Id,
         SessionId = m.SessionId,
+        FolderId = m.FolderId,
         Name = m.Name ?? "",
         CreatedAt = m.CreatedAt,
         UpdatedAt = m.UpdatedAt

--- a/src/CtfDeck.ServerWs/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.ServerWs/WebSocket/WebSocketServer.cs
@@ -5,6 +5,7 @@ using CtfDeck.Abstractions.Ports.Scripts;
 using CtfDeck.Abstractions.Ports.Sessions;
 using CtfDeck.Abstractions.Ports.WriteUps;
 using CtfDeck.Abstractions.Ports.Media;
+using CtfDeck.Abstractions.Ports.Projects;
 
 using CtfDeck.Contracts.Transport;
 
@@ -13,11 +14,13 @@ using CtfDeck.Data.Repositories.Sessions;
 using CtfDeck.Data.Repositories.Scripts;
 using CtfDeck.Data.Repositories.WriteUps;
 using CtfDeck.Data.Repositories.Media;
+using CtfDeck.Data.Repositories.Projects;
 
 using CtfDeck.Terminal.Features.Sessions;
 using CtfDeck.Terminal.Features.Scripts;
 using CtfDeck.Terminal.Features.WriteUps;
 using CtfDeck.Terminal.Features.Media;
+using CtfDeck.Terminal.Features.Projects;
 using CtfDeck.Terminal.Handlers;
 
 namespace CtfDeck.ServerWs.WebSocket;
@@ -57,6 +60,7 @@ public class WebSocketServer
         ICustomScriptRepository customScriptRepository = new CustomScriptRepository(_dbContext);
         IWriteUpRepository writeUpRepository = new WriteUpRepository(_dbContext);
         IMediaRepository mediaRepository = new MediaRepository(_dbContext);
+        IProjectRepository projectRepository = new ProjectRepository(_dbContext);
 
         // Services / handlers
         var sessionService = new SessionService(sessionRepository);
@@ -66,13 +70,15 @@ public class WebSocketServer
         var customScriptService = new CustomScriptService(customScriptRepository);
         var writeUpService = new WriteUpService(writeUpRepository);
         var mediaService = new MediaService(mediaRepository);
+        var projectService = new ProjectService(projectRepository, sessionRepository, writeUpRepository);
 
         _messageHandlers =
         [
             new SessionMessageHandler(sessionService, _activeSessionManager),
             new CustomScriptMessageHandler(customScriptService),
             new WriteUpMessageHandler(writeUpService),
-            new MediaMessageHandler(mediaService)
+            new MediaMessageHandler(mediaService),
+            new ProjectMessageHandler(projectService)
         ];
     }
 

--- a/src/CtfDeck.Terminal/Features/Projects/ProjectService.cs
+++ b/src/CtfDeck.Terminal/Features/Projects/ProjectService.cs
@@ -1,0 +1,90 @@
+using CtfDeck.Contracts.Models.Projects;
+using CtfDeck.Contracts.Models.Sessions;
+using CtfDeck.Contracts.Models.WriteUps;
+using CtfDeck.Abstractions.Ports.Projects;
+using CtfDeck.Abstractions.Ports.Sessions;
+using CtfDeck.Abstractions.Ports.WriteUps;
+
+namespace CtfDeck.Terminal.Features.Projects;
+
+public class ProjectService
+{
+    private readonly IProjectRepository _projectRepository;
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IWriteUpRepository _writeUpRepository;
+
+    public ProjectService(
+        IProjectRepository projectRepository,
+        ISessionRepository sessionRepository,
+        IWriteUpRepository writeUpRepository)
+    {
+        _projectRepository = projectRepository;
+        _sessionRepository = sessionRepository;
+        _writeUpRepository = writeUpRepository;
+    }
+
+    public ProjectDto Create(string name, string description)
+        => _projectRepository.Create(name, description);
+
+    public ProjectDto? GetById(Guid id)
+        => _projectRepository.GetById(id);
+
+    public IEnumerable<ProjectMetadataDto> GetAllMetadata()
+    {
+        var projects = _projectRepository.GetAllMetadata().ToList();
+
+        foreach (var project in projects)
+        {
+            project.SessionCount = _sessionRepository.GetByProjectId(project.Id).Count();
+        }
+
+        return projects;
+    }
+
+    public bool Update(Guid id, string name, string description)
+        => _projectRepository.Update(id, name, description);
+
+    public bool Delete(Guid id)
+    {
+        var folderIds = _projectRepository.GetFolderIds(id);
+
+        _sessionRepository.ClearProjectId(id);
+
+        foreach (var folderId in folderIds)
+        {
+            _writeUpRepository.ClearFolderId(folderId);
+        }
+
+        return _projectRepository.Delete(id);
+    }
+
+    public ProjectFolderDto? AddFolder(Guid projectId, string name)
+        => _projectRepository.AddFolder(projectId, name);
+
+    public bool DeleteFolder(Guid projectId, Guid folderId)
+    {
+        _writeUpRepository.ClearFolderId(folderId);
+        return _projectRepository.DeleteFolder(projectId, folderId);
+    }
+
+    public bool RenameFolder(Guid projectId, Guid folderId, string name)
+        => _projectRepository.RenameFolder(projectId, folderId, name);
+
+    public bool AssignSession(Guid sessionId, Guid projectId)
+    {
+        var actualProjectId = projectId == Guid.Empty ? (Guid?)null : projectId;
+        return _sessionRepository.SetProjectId(sessionId, actualProjectId);
+    }
+
+    public bool MoveWriteUp(Guid writeUpId, Guid folderId)
+    {
+        var actualFolderId = folderId == Guid.Empty ? (Guid?)null : folderId;
+        return _writeUpRepository.SetFolderId(writeUpId, actualFolderId);
+    }
+
+    public List<SessionMetadataDto> ListSessions(Guid projectId)
+        => _sessionRepository.GetByProjectId(projectId).ToList();
+
+    public List<WriteUpMetadataDto> ListWriteUps(Guid folderId)
+        => _writeUpRepository.GetByFolderId(folderId);
+}

--- a/src/CtfDeck.Terminal/Handlers/ProjectMessageHandler.cs
+++ b/src/CtfDeck.Terminal/Handlers/ProjectMessageHandler.cs
@@ -1,0 +1,126 @@
+using CtfDeck.Terminal.Features.Projects;
+using CtfDeck.Contracts.Transport;
+using CtfDeck.Contracts.Protocols.Project;
+
+namespace CtfDeck.Terminal.Handlers;
+
+public sealed class ProjectMessageHandler : MessageHandlerBase
+{
+    private readonly ProjectService _projectService;
+
+    public ProjectMessageHandler(ProjectService projectService)
+    {
+        _projectService = projectService;
+    }
+
+    protected override bool CanHandle(MessageType type)
+        => ProjectProtocolDeserializer.IsProjectMessage(type);
+
+    protected override byte[] SerializeError(Guid messageId, string error)
+        => ProjectProtocolSerializer.SerializeError(messageId, error);
+
+    protected override byte[] Dispatch(string clientId, MessageType type, ReadOnlySpan<byte> data)
+    {
+        return type switch
+        {
+            MessageType.ProjectCreate => HandleCreate(data),
+            MessageType.ProjectLoad => HandleLoad(data),
+            MessageType.ProjectList => HandleList(data),
+            MessageType.ProjectUpdate => HandleUpdate(data),
+            MessageType.ProjectDelete => HandleDelete(data),
+            MessageType.ProjectAddFolder => HandleAddFolder(data),
+            MessageType.ProjectDeleteFolder => HandleDeleteFolder(data),
+            MessageType.ProjectRenameFolder => HandleRenameFolder(data),
+            MessageType.ProjectAssignSession => HandleAssignSession(data),
+            MessageType.WriteUpMove => HandleWriteUpMove(data),
+            MessageType.ProjectListSessions => HandleListSessions(data),
+            MessageType.ProjectListWriteUps => HandleListWriteUps(data),
+            _ => throw new InvalidOperationException($"Unknown project message type: {type}")
+        };
+    }
+
+    private byte[] HandleCreate(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectCreateRequest(data);
+        var project = _projectService.Create(request.Name, request.Description);
+        return ProjectProtocolSerializer.SerializeCreateResult(request.MessageId, true, project.Id);
+    }
+
+    private byte[] HandleLoad(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectLoadRequest(data);
+        var project = _projectService.GetById(request.ProjectId);
+        return ProjectProtocolSerializer.SerializeLoadResult(request.MessageId, project != null, project);
+    }
+
+    private byte[] HandleList(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectListRequest(data);
+        var projects = _projectService.GetAllMetadata();
+        return ProjectProtocolSerializer.SerializeListResult(request.MessageId, projects);
+    }
+
+    private byte[] HandleUpdate(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectUpdateRequest(data);
+        var success = _projectService.Update(request.ProjectId, request.Name, request.Description);
+        return ProjectProtocolSerializer.SerializeUpdateResult(request.MessageId, success);
+    }
+
+    private byte[] HandleDelete(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectDeleteRequest(data);
+        var success = _projectService.Delete(request.ProjectId);
+        return ProjectProtocolSerializer.SerializeDeleteResult(request.MessageId, success);
+    }
+
+    private byte[] HandleAddFolder(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectAddFolderRequest(data);
+        var folder = _projectService.AddFolder(request.ProjectId, request.Name);
+        return ProjectProtocolSerializer.SerializeAddFolderResult(
+            request.MessageId, folder != null, folder?.Id ?? Guid.Empty);
+    }
+
+    private byte[] HandleDeleteFolder(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectDeleteFolderRequest(data);
+        var success = _projectService.DeleteFolder(request.ProjectId, request.FolderId);
+        return ProjectProtocolSerializer.SerializeDeleteFolderResult(request.MessageId, success);
+    }
+
+    private byte[] HandleRenameFolder(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectRenameFolderRequest(data);
+        var success = _projectService.RenameFolder(request.ProjectId, request.FolderId, request.Name);
+        return ProjectProtocolSerializer.SerializeRenameFolderResult(request.MessageId, success);
+    }
+
+    private byte[] HandleAssignSession(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectAssignSessionRequest(data);
+        var success = _projectService.AssignSession(request.SessionId, request.ProjectId);
+        return ProjectProtocolSerializer.SerializeAssignSessionResult(request.MessageId, success);
+    }
+
+    private byte[] HandleWriteUpMove(ReadOnlySpan<byte> data)
+    {
+        var request = new WriteUpMoveRequest(data);
+        var success = _projectService.MoveWriteUp(request.WriteUpId, request.FolderId);
+        return ProjectProtocolSerializer.SerializeWriteUpMoveResult(request.MessageId, success);
+    }
+
+    private byte[] HandleListSessions(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectListSessionsRequest(data);
+        var sessions = _projectService.ListSessions(request.ProjectId);
+        return ProjectProtocolSerializer.SerializeListSessionsResult(request.MessageId, sessions);
+    }
+
+    private byte[] HandleListWriteUps(ReadOnlySpan<byte> data)
+    {
+        var request = new ProjectListWriteUpsRequest(data);
+        var writeUps = _projectService.ListWriteUps(request.FolderId);
+        return ProjectProtocolSerializer.SerializeListWriteUpsResult(request.MessageId, writeUps);
+    }
+}

--- a/tests/CtfDeck.Tests/Project/ProjectProtocolTests.cs
+++ b/tests/CtfDeck.Tests/Project/ProjectProtocolTests.cs
@@ -1,0 +1,423 @@
+using CtfDeck.Contracts.Models.Projects;
+using CtfDeck.Contracts.Models.Sessions;
+using CtfDeck.Contracts.Models.WriteUps;
+using CtfDeck.Contracts.Protocols.Project;
+using CtfDeck.Contracts.Transport;
+using FluentAssertions;
+
+namespace CtfDeck.Tests.Project;
+
+public class ProjectProtocolTests
+{
+    [Fact]
+    public void ProjectCreateRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var name = "My CTF Project";
+        var description = "A project for HackTheBox";
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectCreate);
+        writer.WriteGuid(messageId);
+        writer.WriteString(name);
+        writer.WriteString(description);
+        var data = writer.ToArray();
+
+        var request = new ProjectCreateRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.Name.Should().Be(name);
+        request.Description.Should().Be(description);
+    }
+
+    [Fact]
+    public void ProjectLoadRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectLoad);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(projectId);
+        var data = writer.ToArray();
+
+        var request = new ProjectLoadRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.ProjectId.Should().Be(projectId);
+    }
+
+    [Fact]
+    public void ProjectListRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectList);
+        writer.WriteGuid(messageId);
+        var data = writer.ToArray();
+
+        var request = new ProjectListRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+    }
+
+    [Fact]
+    public void ProjectUpdateRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var name = "Updated Project";
+        var description = "Updated description";
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectUpdate);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(projectId);
+        writer.WriteString(name);
+        writer.WriteString(description);
+        var data = writer.ToArray();
+
+        var request = new ProjectUpdateRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.ProjectId.Should().Be(projectId);
+        request.Name.Should().Be(name);
+        request.Description.Should().Be(description);
+    }
+
+    [Fact]
+    public void ProjectDeleteRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectDelete);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(projectId);
+        var data = writer.ToArray();
+
+        var request = new ProjectDeleteRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.ProjectId.Should().Be(projectId);
+    }
+
+    [Fact]
+    public void ProjectAddFolderRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var name = "Exploits";
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectAddFolder);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(projectId);
+        writer.WriteString(name);
+        var data = writer.ToArray();
+
+        var request = new ProjectAddFolderRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.ProjectId.Should().Be(projectId);
+        request.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void ProjectDeleteFolderRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var folderId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectDeleteFolder);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(projectId);
+        writer.WriteGuid(folderId);
+        var data = writer.ToArray();
+
+        var request = new ProjectDeleteFolderRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.ProjectId.Should().Be(projectId);
+        request.FolderId.Should().Be(folderId);
+    }
+
+    [Fact]
+    public void ProjectRenameFolderRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var folderId = Guid.NewGuid();
+        var name = "Renamed Folder";
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectRenameFolder);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(projectId);
+        writer.WriteGuid(folderId);
+        writer.WriteString(name);
+        var data = writer.ToArray();
+
+        var request = new ProjectRenameFolderRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.ProjectId.Should().Be(projectId);
+        request.FolderId.Should().Be(folderId);
+        request.Name.Should().Be(name);
+    }
+
+    [Fact]
+    public void ProjectAssignSessionRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectAssignSession);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(sessionId);
+        writer.WriteGuid(projectId);
+        var data = writer.ToArray();
+
+        var request = new ProjectAssignSessionRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.SessionId.Should().Be(sessionId);
+        request.ProjectId.Should().Be(projectId);
+    }
+
+    [Fact]
+    public void WriteUpMoveRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var writeUpId = Guid.NewGuid();
+        var folderId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpMove);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(writeUpId);
+        writer.WriteGuid(folderId);
+        var data = writer.ToArray();
+
+        var request = new WriteUpMoveRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.WriteUpId.Should().Be(writeUpId);
+        request.FolderId.Should().Be(folderId);
+    }
+
+    [Fact]
+    public void WriteUpMoveRequest_WithEmptyGuid_ShouldDeserializeAsUnlink()
+    {
+        var messageId = Guid.NewGuid();
+        var writeUpId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.WriteUpMove);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(writeUpId);
+        writer.WriteGuid(Guid.Empty);
+        var data = writer.ToArray();
+
+        var request = new WriteUpMoveRequest(data);
+
+        request.FolderId.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
+    public void SerializeCreateResult_ShouldRoundTrip()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        var bytes = ProjectProtocolSerializer.SerializeCreateResult(messageId, true, projectId);
+
+        bytes[0].Should().Be((byte)MessageType.ProjectCreateResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1);
+        var resultProjectId = new Guid(bytes.AsSpan(18, 16));
+        resultProjectId.Should().Be(projectId);
+    }
+
+    [Fact]
+    public void SerializeAddFolderResult_ShouldRoundTrip()
+    {
+        var messageId = Guid.NewGuid();
+        var folderId = Guid.NewGuid();
+
+        var bytes = ProjectProtocolSerializer.SerializeAddFolderResult(messageId, true, folderId);
+
+        bytes[0].Should().Be((byte)MessageType.ProjectAddFolderResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1);
+        var resultFolderId = new Guid(bytes.AsSpan(18, 16));
+        resultFolderId.Should().Be(folderId);
+    }
+
+    [Fact]
+    public void SerializeListResult_ShouldSerializeMultipleEntries()
+    {
+        var messageId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var projects = new List<ProjectMetadataDto>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Project 1", Description = "Desc 1", CreatedAt = now, UpdatedAt = now, FolderCount = 2, SessionCount = 3 },
+            new() { Id = Guid.NewGuid(), Name = "Project 2", Description = "Desc 2", CreatedAt = now, UpdatedAt = now, FolderCount = 1, SessionCount = 0 }
+        };
+
+        var bytes = ProjectProtocolSerializer.SerializeListResult(messageId, projects);
+
+        bytes[0].Should().Be((byte)MessageType.ProjectListResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        var count = BitConverter.ToInt32(bytes.AsSpan(17, 4));
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public void SerializeLoadResult_Success_ShouldContainFullData()
+    {
+        var messageId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var project = new ProjectDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Project",
+            Description = "Test Desc",
+            CreatedAt = now,
+            UpdatedAt = now,
+            Folders = new List<ProjectFolderDto>
+            {
+                new() { Id = Guid.NewGuid(), Name = "Report", IsSystem = true },
+                new() { Id = Guid.NewGuid(), Name = "Custom", IsSystem = false }
+            }
+        };
+
+        var bytes = ProjectProtocolSerializer.SerializeLoadResult(messageId, true, project);
+
+        bytes[0].Should().Be((byte)MessageType.ProjectLoadResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        bytes[17].Should().Be(1);
+        var resultId = new Guid(bytes.AsSpan(18, 16));
+        resultId.Should().Be(project.Id);
+    }
+
+    [Fact]
+    public void SerializeLoadResult_NotFound_ShouldBeMinimal()
+    {
+        var messageId = Guid.NewGuid();
+
+        var bytes = ProjectProtocolSerializer.SerializeLoadResult(messageId, false, null);
+
+        bytes[0].Should().Be((byte)MessageType.ProjectLoadResult);
+        bytes[17].Should().Be(0);
+        bytes.Length.Should().Be(18);
+    }
+
+    [Fact]
+    public void IsProjectMessage_ShouldDetectCorrectRange()
+    {
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectCreate).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectLoad).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectList).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectUpdate).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectDelete).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectAddFolder).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectDeleteFolder).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectRenameFolder).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectAssignSession).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.WriteUpMove).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectListSessions).Should().BeTrue();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.ProjectListWriteUps).Should().BeTrue();
+
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.SessionCreate).Should().BeFalse();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.WriteUpCreate).Should().BeFalse();
+        ProjectProtocolDeserializer.IsProjectMessage(MessageType.MediaUpload).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProjectListSessionsRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectListSessions);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(projectId);
+        var data = writer.ToArray();
+
+        var request = new ProjectListSessionsRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.ProjectId.Should().Be(projectId);
+    }
+
+    [Fact]
+    public void ProjectListWriteUpsRequest_ShouldDeserializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var folderId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.ProjectListWriteUps);
+        writer.WriteGuid(messageId);
+        writer.WriteGuid(folderId);
+        var data = writer.ToArray();
+
+        var request = new ProjectListWriteUpsRequest(data);
+
+        request.MessageId.Should().Be(messageId);
+        request.FolderId.Should().Be(folderId);
+    }
+
+    [Fact]
+    public void SerializeListSessionsResult_ShouldSerializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var sessions = new List<SessionMetadataDto>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Session 1", Description = "Desc", CreatedAt = now, UpdatedAt = now, HistoryCount = 5, TargetCount = 2, ProjectId = Guid.NewGuid() },
+            new() { Id = Guid.NewGuid(), Name = "Session 2", Description = "", CreatedAt = now, UpdatedAt = now, HistoryCount = 0, TargetCount = 0, ProjectId = null }
+        };
+
+        var bytes = ProjectProtocolSerializer.SerializeListSessionsResult(messageId, sessions);
+
+        bytes[0].Should().Be((byte)MessageType.ProjectListSessionsResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        var count = BitConverter.ToInt32(bytes.AsSpan(17, 4));
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public void SerializeListWriteUpsResult_ShouldSerializeCorrectly()
+    {
+        var messageId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var writeUps = new List<WriteUpMetadataDto>
+        {
+            new() { Id = Guid.NewGuid(), SessionId = Guid.NewGuid(), FolderId = Guid.NewGuid(), Name = "WriteUp 1", CreatedAt = now, UpdatedAt = now },
+            new() { Id = Guid.NewGuid(), SessionId = Guid.NewGuid(), FolderId = null, Name = "WriteUp 2", CreatedAt = now, UpdatedAt = now }
+        };
+
+        var bytes = ProjectProtocolSerializer.SerializeListWriteUpsResult(messageId, writeUps);
+
+        bytes[0].Should().Be((byte)MessageType.ProjectListWriteUpsResult);
+        var resultMsgId = new Guid(bytes.AsSpan(1, 16));
+        resultMsgId.Should().Be(messageId);
+        var count = BitConverter.ToInt32(bytes.AsSpan(17, 4));
+        count.Should().Be(2);
+    }
+}


### PR DESCRIPTION
This pull request introduces a major update to the database schema and protocol documentation, adding support for CTF project management and folder organization. It also extends write-up functionality to allow folder assignment and movement, and updates the project structure documentation to reflect these new features. The most important changes are grouped below.

**Project Management Features**

* Added a new `projects` collection to the database schema, with embedded `ProjectFolder` documents for organizing write-ups. Each project groups sessions and folders, and system folders (like "Report") are protected from deletion/renaming. (`docs/DATABASE.md`) [[1]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR56-R65) [[2]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR340-R411)
* Introduced new protocol message types for project CRUD, folder management, session assignment, and listing sessions/write-ups by project or folder. (`docs/PROTOCOL.md`)

**Write-Up Folder Assignment**

* Added `FolderId` field to write-up documents and schema, allowing write-ups to be linked to specific project folders or left unlinked. (`docs/DATABASE.md`) [[1]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR44) [[2]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR275) [[3]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR287)
* Extended protocol to support moving write-ups between folders, including new message formats for move requests and results. (`docs/PROTOCOL.md`) [[1]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR112-R118) [[2]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR969-R970) [[3]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR1021-R1031) [[4]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eL1033-R1077) [[5]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eL1053-R1108)

**Session-Project Linking**

* Added `ProjectId` field to session documents and schema, allowing sessions to be linked to projects or left unlinked. Protocol message formats updated to include project ID in session serialization. (`docs/DATABASE.md`, `docs/PROTOCOL.md`) [[1]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR24) [[2]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR81) [[3]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR94) [[4]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eL601-R628) [[5]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR668)

**Documentation and Project Structure Updates**

* Updated project structure documentation to include new folders, DTOs, repositories, services, and handlers for project and folder management. (`docs/PROJECT_STRUCTURE.md`, `docs/DATABASE.md`) [[1]](diffhunk://#diff-dadd9786ef8658411f5a35c9f44b0668edb3b7d6518612f2fe4490b1018baf07L35-R36) [[2]](diffhunk://#diff-dadd9786ef8658411f5a35c9f44b0668edb3b7d6518612f2fe4490b1018baf07R47-R52) [[3]](diffhunk://#diff-dadd9786ef8658411f5a35c9f44b0668edb3b7d6518612f2fe4490b1018baf07R62-R74) [[4]](diffhunk://#diff-dadd9786ef8658411f5a35c9f44b0668edb3b7d6518612f2fe4490b1018baf07R85) [[5]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR474-R478) [[6]](diffhunk://#diff-9f9ec8185cc5099bb6ac5603330f805ea1898a4172bc2beb09841ed0a7c0428bR521-R523)

**Miscellaneous**

* Changed default database filename to `ctfdeck.db` for production. (`docs/DATABASE.md`)
* Updated documentation headers and improved clarity in schema descriptions. (`docs/DATABASE.md`)

These changes lay the foundation for robust project and folder management within the CTFDeck application, enabling better organization of sessions and write-ups.