### PR TITLE
feature/signal-handling

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -75,6 +75,7 @@ All message types (1-byte prefix):
 | CommandKill | 4 | Client → Server | Cancel a running command |
 | CommandKillResult | 5 | Server → Client | Kill result |
 | CommandExecute | 6 | Client → Server | Execute a terminal command |
+| CommandSignal | 9 | Client → Server | Send Ctrl+C (Interrupt) or Ctrl+D (Eof) to a running command — fire-and-forget |
 | SessionCreate | 10 | Client → Server | Create a new session |
 | SessionSetActive | 11 | Client → Server | Set active session for recording |
 | SessionLoad | 12 | Client → Server | Load full session data |
@@ -427,6 +428,29 @@ OFFSET | SIZE | TYPE      | DESCRIPTION
 - When a command is killed, it sends a `StreamEnd` message with `exitCode = -1` before the `CommandKillResult`
 - If the command has already finished, `success` will be `0`
 - On client disconnect, all active commands for that client are automatically cancelled
+
+### CommandSignal
+
+Allows the client to send soft terminal signals to a running command — Ctrl+C (interrupt) or Ctrl+D (EOF on stdin). Fire-and-forget: no ack is sent; the effect is observed via the command's normal output/`StreamEnd`.
+
+#### CommandSignal (client → server)
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (9)
+1      | 16   | bytes[16] | Command ID (UUID of the target running command)
+17     | 1    | byte      | Signal kind (0 = Interrupt / Ctrl+C, 1 = Eof / Ctrl+D)
+```
+
+**Total Size:** 18 bytes
+
+**Signal kinds:**
+- `0` — **Interrupt** (Ctrl+C): cancels the command's `CancellationTokenSource`, resulting in `process.Kill(entireProcessTree: true)` and a `StreamEnd` with `exitCode = -1`. Semantically equivalent to `CommandKill` but mapped to the keyboard event rather than an explicit "Kill" button.
+- `1` — **Eof** (Ctrl+D): closes the target process's stdin, signaling end-of-file. Lets interactive commands that read stdin (`cat`, `wc`, `python -`) exit cleanly with their normal exit code.
+
+**Notes:**
+- No response message is sent. If the `commandId` does not match an active command, the signal is silently dropped (logged server-side).
+- For a command to be interruptible/eof-able, it must be an active streaming command tracked in the client context.
+- Process stdin remains open for the full lifetime of every streaming command so that Eof has meaning at any time.
 
 ---
 

--- a/src/CtfDeck.Contracts/Transport/MessageType.cs
+++ b/src/CtfDeck.Contracts/Transport/MessageType.cs
@@ -15,6 +15,7 @@ public enum MessageType : byte
     CommandExecute = 6,
     PasswordRequest = 7,    // Server -> Client
     PasswordProvide = 8,    // Client -> Server
+    CommandSignal = 9,      // Client -> Server (Ctrl+C / Ctrl+D, fire-and-forget)
 
     // Session requests (client → server)
     SessionCreate = 10,

--- a/src/CtfDeck.Contracts/Transport/TerminalProtocol.cs
+++ b/src/CtfDeck.Contracts/Transport/TerminalProtocol.cs
@@ -164,6 +164,26 @@ public readonly ref struct CommandKillReader
     }
 }
 
+public enum CommandSignalKind : byte
+{
+    Interrupt = 0,
+    Eof = 1
+}
+
+public readonly ref struct CommandSignalReader
+{
+    public readonly Guid CommandId;
+    public readonly CommandSignalKind Kind;
+
+    public CommandSignalReader(ReadOnlySpan<byte> data)
+    {
+        var reader = new BinaryProtocolReader(data);
+        reader.ReadByte(); // type: CommandSignal (9)
+        CommandId = reader.ReadGuid();
+        Kind = (CommandSignalKind)reader.ReadByte();
+    }
+}
+
 public readonly ref struct PasswordProvideReader
 {
     public readonly Guid MessageId;

--- a/src/CtfDeck.Terminal/Terminal/Execution/ProcessRunner.cs
+++ b/src/CtfDeck.Terminal/Terminal/Execution/ProcessRunner.cs
@@ -15,6 +15,7 @@ public static class ProcessRunner
         string workingDirectory,
         Func<string, bool, Task> onOutput,
         Func<StreamWriter, Task>? writeStdin = null,
+        Action<StreamWriter>? onStdinReady = null,
         CancellationToken cancellationToken = default)
     {
         using var process = CreateProcess(shell, command, workingDirectory);
@@ -26,17 +27,20 @@ public static class ProcessRunner
         {
             process.Start();
 
-            // If sudoPassword was provided, write it ASAP to stdin
+            // If sudoPassword was provided, write it ASAP to stdin (kept open for EOF signal)
             if (writeStdin != null)
             {
                 try
                 {
                     await writeStdin(process.StandardInput);
                     await process.StandardInput.FlushAsync();
-                    process.StandardInput.Close();
                 }
                 catch { /* ignore */ }
             }
+
+            // Publish stdin to the caller so it can close it on EOF (Ctrl+D) signal
+            try { onStdinReady?.Invoke(process.StandardInput); }
+            catch { /* ignore */ }
 
             using var timeoutCts = new CancellationTokenSource(DefaultTimeout);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);

--- a/src/CtfDeck.Terminal/Terminal/TerminalExecutor.cs
+++ b/src/CtfDeck.Terminal/Terminal/TerminalExecutor.cs
@@ -38,7 +38,8 @@ public sealed class TerminalExecutor : IDisposable
         string command,
         OutputReceivedHandler onOutput,
         CancellationToken cancellationToken = default,
-        string? sudoPassword = null)
+        string? sudoPassword = null,
+        Action<StreamWriter>? onStdinReady = null)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
 
@@ -47,7 +48,7 @@ public sealed class TerminalExecutor : IDisposable
 
         return CommandPreprocessor.IsDirectoryChangeCommand(resolvedCommand)
             ? ExecuteCdAsync(resolvedCommand, onOutput)
-            : ExecuteShellCommandAsync(resolvedCommand, onOutput, cancellationToken, sudoPassword);
+            : ExecuteShellCommandAsync(resolvedCommand, onOutput, cancellationToken, sudoPassword, onStdinReady);
     }
 
     public async Task<CommandResult> ExecuteAsync(
@@ -106,7 +107,8 @@ public sealed class TerminalExecutor : IDisposable
         string command,
         OutputReceivedHandler onOutput,
         CancellationToken cancellationToken,
-        string? sudoPassword)
+        string? sudoPassword,
+        Action<StreamWriter>? onStdinReady)
     {
         try
         {
@@ -129,6 +131,7 @@ public sealed class TerminalExecutor : IDisposable
                     (sudoPassword != null && IsSudo(command))
                         ? (sw => sw.WriteLineAsync(sudoPassword))
                         : null,
+                onStdinReady: onStdinReady,
                 cancellationToken: cancellationToken
             );
         }

--- a/src/CtfDeck.WsServer/WebSocket/BinaryMessageDispatcher.cs
+++ b/src/CtfDeck.WsServer/WebSocket/BinaryMessageDispatcher.cs
@@ -8,6 +8,7 @@ public sealed class BinaryMessageDispatcher
     private readonly Func<ClientContext, WebSocketCommand, Task> _processCdAsync;
     private readonly Func<ClientContext, WebSocketCommand, Task> _processStreamingAsync;
     private readonly Func<ClientContext, Guid, Task> _handleKillAsync;
+    private readonly Func<ClientContext, Guid, CommandSignalKind, Task> _handleSignalAsync;
     private readonly IReadOnlyList<MessageHandlerBase> _messageHandlers;
     private readonly Action<string> _log;
 
@@ -15,12 +16,14 @@ public sealed class BinaryMessageDispatcher
         Func<ClientContext, WebSocketCommand, Task> processCdAsync,
         Func<ClientContext, WebSocketCommand, Task> processStreamingAsync,
         Func<ClientContext, Guid, Task> handleKillAsync,
+        Func<ClientContext, Guid, CommandSignalKind, Task> handleSignalAsync,
         IReadOnlyList<MessageHandlerBase> messageHandlers,
         Action<string>? log = null)
     {
         _processCdAsync = processCdAsync;
         _processStreamingAsync = processStreamingAsync;
         _handleKillAsync = handleKillAsync;
+        _handleSignalAsync = handleSignalAsync;
         _messageHandlers = messageHandlers;
         _log = log ?? Console.WriteLine;
     }
@@ -54,6 +57,13 @@ public sealed class BinaryMessageDispatcher
                 {
                     var killCommandId = new CommandKillReader(message.Span).CommandId;
                     await _handleKillAsync(ctx, killCommandId);
+                    break;
+                }
+
+            case MessageType.CommandSignal:
+                {
+                    var signalReader = new CommandSignalReader(message.Span);
+                    await _handleSignalAsync(ctx, signalReader.CommandId, signalReader.Kind);
                     break;
                 }
 

--- a/src/CtfDeck.WsServer/WebSocket/ClientContext.cs
+++ b/src/CtfDeck.WsServer/WebSocket/ClientContext.cs
@@ -13,6 +13,7 @@ public sealed class ClientContext : IDisposable
     public WebSocketSender Sender { get; }
     public ConcurrentDictionary<Guid, CancellationTokenSource> ActiveCommands { get; } = new();
     public ConcurrentDictionary<Guid, TaskCompletionSource<string?>> SudoWaiters { get; } = new();
+    public ConcurrentDictionary<Guid, Action> ActiveStdinClosers { get; } = new();
 
     public ClientContext(string clientId, System.Net.WebSockets.WebSocket webSocket)
     {
@@ -31,6 +32,14 @@ public sealed class ClientContext : IDisposable
         }
 
         ActiveCommands.Clear();
+
+        foreach (var close in ActiveStdinClosers.Values)
+        {
+            try { close(); }
+            catch { /* stream already disposed */ }
+        }
+
+        ActiveStdinClosers.Clear();
         try
         {
             if (WebSocket.State != WebSocketState.Closed && WebSocket.State != WebSocketState.Aborted)

--- a/src/CtfDeck.WsServer/WebSocket/CommandDispatcher.cs
+++ b/src/CtfDeck.WsServer/WebSocket/CommandDispatcher.cs
@@ -82,7 +82,12 @@ public sealed class CommandDispatcher
                 resolvedCommand,
                 (data, isError) => batcher.EnqueueAsync(data, isError).AsTask(),
                 cts.Token,
-                sudoPassword);
+                sudoPassword,
+                sw => ctx.ActiveStdinClosers.TryAdd(command.MessageId, () =>
+                {
+                    try { sw.Close(); }
+                    catch { /* process may have already exited */ }
+                }));
 
             var accumulatedOutput = await batcher.CompleteAsync(streamResult.ExitCode, executor.CurrentDirectory);
 
@@ -113,6 +118,7 @@ public sealed class CommandDispatcher
         finally
         {
             ctx.ActiveCommands.TryRemove(command.MessageId, out _);
+            ctx.ActiveStdinClosers.TryRemove(command.MessageId, out _);
         }
     }
 
@@ -140,6 +146,43 @@ public sealed class CommandDispatcher
 
         var killResult = TerminalProtocolSerializer.SerializeCommandKillResult(commandId, success);
         await ctx.Sender.SendAsync(killResult);
+    }
+
+    /// <summary>
+    /// Handle CommandSignal message — Ctrl+C (Interrupt) or Ctrl+D (Eof). Fire-and-forget.
+    /// </summary>
+    public Task HandleSignalAsync(ClientContext ctx, Guid commandId, CommandSignalKind kind)
+    {
+        switch (kind)
+        {
+            case CommandSignalKind.Interrupt:
+                if (ctx.ActiveCommands.TryGetValue(commandId, out var cts))
+                {
+                    try { cts.Cancel(); }
+                    catch (ObjectDisposedException) { /* already finished */ }
+                    Console.WriteLine($"[SIGNAL] {commandId} → interrupt");
+                }
+                else
+                {
+                    Console.WriteLine($"[SIGNAL] {commandId} → interrupt (not found)");
+                }
+                return Task.CompletedTask;
+
+            case CommandSignalKind.Eof:
+                if (ctx.ActiveStdinClosers.TryGetValue(commandId, out var close))
+                {
+                    close();
+                    Console.WriteLine($"[SIGNAL] {commandId} → eof");
+                }
+                else
+                {
+                    Console.WriteLine($"[SIGNAL] {commandId} → eof (not found)");
+                }
+                return Task.CompletedTask;
+
+            default:
+                return Task.CompletedTask;
+        }
     }
 
     /// <summary>

--- a/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
@@ -115,6 +115,7 @@ public class WebSocketServer : IServerHost
             _commandDispatcher.ProcessCdAsync,
             _commandDispatcher.ProcessStreamingAsync,
             _commandDispatcher.HandleKillAsync,
+            _commandDispatcher.HandleSignalAsync,
             _messageHandlers,
             Console.WriteLine);
     }

--- a/tests/CtfDeck.Tests/WebSocket/BinaryMessageDispatcherTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/BinaryMessageDispatcherTests.cs
@@ -30,6 +30,7 @@ public class BinaryMessageDispatcherTests
                 return Task.CompletedTask;
             },
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         var payload = CreateCommandExecute("cd /tmp", Guid.NewGuid());
@@ -57,6 +58,7 @@ public class BinaryMessageDispatcherTests
                 return Task.CompletedTask;
             },
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         var payload = CreateCommandExecute("echo ok", Guid.NewGuid());
@@ -83,6 +85,7 @@ public class BinaryMessageDispatcherTests
                 actualId = id;
                 return Task.CompletedTask;
             },
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -92,6 +95,41 @@ public class BinaryMessageDispatcherTests
         await dispatcher.DispatchAsync(ctx, writer.ToArray(), CancellationToken.None);
 
         actualId.Should().Be(expectedId);
+    }
+
+    [Theory]
+    [InlineData(CommandSignalKind.Interrupt)]
+    [InlineData(CommandSignalKind.Eof)]
+    public async Task DispatchAsync_CommandSignal_ShouldCallSignalHandler(CommandSignalKind kind)
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal", socket);
+
+        var expectedId = Guid.NewGuid();
+        Guid? actualId = null;
+        CommandSignalKind? actualKind = null;
+
+        var dispatcher = new BinaryMessageDispatcher(
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            (_, id, k) =>
+            {
+                actualId = id;
+                actualKind = k;
+                return Task.CompletedTask;
+            },
+            []);
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.CommandSignal);
+        writer.WriteGuid(expectedId);
+        writer.WriteByte((byte)kind);
+
+        await dispatcher.DispatchAsync(ctx, writer.ToArray(), CancellationToken.None);
+
+        actualId.Should().Be(expectedId);
+        actualKind.Should().Be(kind);
     }
 
     [Fact]
@@ -105,6 +143,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -131,6 +170,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -156,6 +196,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             [],
             logs.Add);
 
@@ -176,6 +217,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             [handler],
             logs.Add);
 

--- a/tests/CtfDeck.Tests/WebSocket/BinaryProtocolTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/BinaryProtocolTests.cs
@@ -321,4 +321,28 @@ public class BinaryProtocolTests
         binaryData.Length.Should().BeGreaterThan(0);
         binaryData[0].Should().Be((byte)MessageType.StreamEnd);
     }
+
+    [Theory]
+    [InlineData(CommandSignalKind.Interrupt)]
+    [InlineData(CommandSignalKind.Eof)]
+    public void CommandSignalReader_ShouldParseWireFormat(CommandSignalKind kind)
+    {
+        // Arrange: [1B type=9][16B commandId][1B signalKind] — total 18 bytes
+        var commandId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter(18);
+        writer.WriteByte((byte)MessageType.CommandSignal);
+        writer.WriteGuid(commandId);
+        writer.WriteByte((byte)kind);
+        var payload = writer.ToArray();
+
+        // Act
+        var reader = new CommandSignalReader(payload);
+
+        // Assert
+        payload.Length.Should().Be(18);
+        payload[0].Should().Be((byte)MessageType.CommandSignal);
+        reader.CommandId.Should().Be(commandId);
+        reader.Kind.Should().Be(kind);
+    }
 }

--- a/tests/CtfDeck.Tests/WebSocket/CommandDispatcherTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/CommandDispatcherTests.cs
@@ -114,6 +114,54 @@ public sealed class CommandDispatcherTests : IDisposable
     }
 
     [Fact]
+    public async Task HandleSignalAsync_Interrupt_ShouldCancelActiveCommand()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal-int", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+        var commandId = Guid.NewGuid();
+        using var cts = new CancellationTokenSource();
+        ctx.ActiveCommands[commandId] = cts;
+
+        await dispatcher.HandleSignalAsync(ctx, commandId, CommandSignalKind.Interrupt);
+
+        cts.IsCancellationRequested.Should().BeTrue();
+        socket.SentMessages.Should().BeEmpty(); // fire-and-forget, no ack
+    }
+
+    [Fact]
+    public async Task HandleSignalAsync_Eof_ShouldInvokeStdinCloser()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal-eof", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+        var commandId = Guid.NewGuid();
+        var closed = false;
+        ctx.ActiveStdinClosers[commandId] = () => closed = true;
+
+        await dispatcher.HandleSignalAsync(ctx, commandId, CommandSignalKind.Eof);
+
+        closed.Should().BeTrue();
+        socket.SentMessages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleSignalAsync_UnknownCommand_ShouldNotThrow()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal-missing", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+
+        var act = async () =>
+        {
+            await dispatcher.HandleSignalAsync(ctx, Guid.NewGuid(), CommandSignalKind.Interrupt);
+            await dispatcher.HandleSignalAsync(ctx, Guid.NewGuid(), CommandSignalKind.Eof);
+        };
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task ProcessStreamingAsync_SudoWithoutPassword_ShouldEmitKilledStreamEnd()
     {
         var socket = new MockWebSocket();

--- a/tests/CtfDeck.Tests/WebSocket/WebSocketIntegrationTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/WebSocketIntegrationTests.cs
@@ -516,14 +516,23 @@ public class WebSocketIntegrationTests : IDisposable
         // Act
         await _server.StopAsync();
 
-        // Wait for client to detect closure
-        try
+        // Drain any buffered server messages (e.g. initial ToolCatalogSnapshot) until the
+        // client observes the close/abort — a single receive is fragile because the first
+        // frame may be the catalog, not the close frame.
+        using var drainCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (!drainCts.IsCancellationRequested &&
+               client.State != WebSocketState.CloseReceived &&
+               client.State != WebSocketState.CloseSent &&
+               client.State != WebSocketState.Closed &&
+               client.State != WebSocketState.Aborted)
         {
-            using var waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-            await ReceiveFullMessageBytesAsync(client, waitCts.Token);
+            try
+            {
+                await ReceiveFullMessageBytesAsync(client, drainCts.Token);
+            }
+            catch (WebSocketException) { break; }
+            catch (OperationCanceledException) { break; }
         }
-        catch (WebSocketException) { }
-        catch (OperationCanceledException) { }
 
         // Assert
         client.State.Should().Match(s => s == WebSocketState.CloseReceived || s == WebSocketState.CloseSent || s == WebSocketState.Closed || s == WebSocketState.Aborted);


### PR DESCRIPTION
This pull request introduces support for soft terminal signals (Ctrl+C and Ctrl+D) sent from the client to running commands over the WebSocket protocol. It adds a new "CommandSignal" message type to the protocol, updates the server to handle these signals by either interrupting the process or closing its stdin, and ensures proper resource cleanup. Comprehensive tests are added to verify the new functionality.

**Protocol and Message Handling Changes:**

* Added a new `CommandSignal` message type (type 9) to the protocol, allowing clients to send Ctrl+C (interrupt) or Ctrl+D (EOF) signals to running commands. This is a fire-and-forget message with no response, and its format and semantics are documented in `PROTOCOL.md`. [[1]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR78) [[2]](diffhunk://#diff-8cbca4606296bd03072452103ccee55850ad257f8e6001578ba608efae65f35eR432-R454) [[3]](diffhunk://#diff-9efa007c6e8be4d9c16f8c131a25b9262602c231c2759093efa1ccf73657235aR18)
* Implemented the `CommandSignalReader` and `CommandSignalKind` in the contracts to parse and represent the new message type and its signal kinds.

**Server-Side Implementation:**

* Updated the server's message dispatcher and command dispatcher to handle the new `CommandSignal` message, invoking the appropriate logic to either cancel the command (Ctrl+C) or close stdin (Ctrl+D). [[1]](diffhunk://#diff-1ab3742fd759cf066f8e597c192aa35e23479372efbb6f1494c06c929f72dc58R11-R26) [[2]](diffhunk://#diff-1ab3742fd759cf066f8e597c192aa35e23479372efbb6f1494c06c929f72dc58R63-R69) [[3]](diffhunk://#diff-67963ee399817b81754dfb3a511b5d7b7374cf5822ff3d264d4a6d1589b6f14fR151-R187) [[4]](diffhunk://#diff-e304ae8ea38d684223c8b59f44770d1ca6697f72ef025b5eb918179c6b4c5d6bR118)
* Extended the `ClientContext` to track active stdin closers for each command, ensuring stdin can be closed on demand and resources are cleaned up when the client disconnects. [[1]](diffhunk://#diff-8ac8ab35abb88c3068ea73c505077fcebc318a94384a04be477e1bfef5b644ebR16) [[2]](diffhunk://#diff-8ac8ab35abb88c3068ea73c505077fcebc318a94384a04be477e1bfef5b644ebR35-R42) [[3]](diffhunk://#diff-67963ee399817b81754dfb3a511b5d7b7374cf5822ff3d264d4a6d1589b6f14fR121)

**Process Execution Enhancements:**

* Modified the process execution pipeline to keep stdin open for streaming commands, and to expose a callback for when stdin is ready, enabling the server to close stdin in response to a Ctrl+D signal. [[1]](diffhunk://#diff-caadeaa1a08307941a52d7d81ac57e6c568ddd8497b68e73d40b88487aabd82dR18) [[2]](diffhunk://#diff-caadeaa1a08307941a52d7d81ac57e6c568ddd8497b68e73d40b88487aabd82dL29-R44) [[3]](diffhunk://#diff-cd9292b9adf61fd0668e79d16aebf7fd931f942f619f1b5877ec4805c197de67L41-R42) [[4]](diffhunk://#diff-cd9292b9adf61fd0668e79d16aebf7fd931f942f619f1b5877ec4805c197de67L50-R51) [[5]](diffhunk://#diff-cd9292b9adf61fd0668e79d16aebf7fd931f942f619f1b5877ec4805c197de67L109-R111) [[6]](diffhunk://#diff-cd9292b9adf61fd0668e79d16aebf7fd931f942f619f1b5877ec4805c197de67R134) [[7]](diffhunk://#diff-67963ee399817b81754dfb3a511b5d7b7374cf5822ff3d264d4a6d1589b6f14fL85-R90)

**Testing:**

* Added and updated tests to verify that the dispatcher correctly routes `CommandSignal` messages and that the new handler is invoked with the correct arguments. [[1]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R33) [[2]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R61) [[3]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R88) [[4]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R100-R134) [[5]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R146) [[6]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R173) [[7]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R199) [[8]](diffhunk://#diff-8033158cb2c69f18ef918ea23062fc1673f6b61cd31907251dacda5769334bd0R220)