### PR TITLE
CTFD - 76 - Installing with apt/brew and UAC permission

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -75,6 +75,7 @@ All message types (1-byte prefix):
 | CommandKill | 4 | Client → Server | Cancel a running command |
 | CommandKillResult | 5 | Server → Client | Kill result |
 | CommandExecute | 6 | Client → Server | Execute a terminal command |
+| CommandSignal | 9 | Client → Server | Send Ctrl+C (Interrupt) or Ctrl+D (Eof) to a running command — fire-and-forget |
 | SessionCreate | 10 | Client → Server | Create a new session |
 | SessionSetActive | 11 | Client → Server | Set active session for recording |
 | SessionLoad | 12 | Client → Server | Load full session data |
@@ -427,6 +428,29 @@ OFFSET | SIZE | TYPE      | DESCRIPTION
 - When a command is killed, it sends a `StreamEnd` message with `exitCode = -1` before the `CommandKillResult`
 - If the command has already finished, `success` will be `0`
 - On client disconnect, all active commands for that client are automatically cancelled
+
+### CommandSignal
+
+Allows the client to send soft terminal signals to a running command — Ctrl+C (interrupt) or Ctrl+D (EOF on stdin). Fire-and-forget: no ack is sent; the effect is observed via the command's normal output/`StreamEnd`.
+
+#### CommandSignal (client → server)
+```
+OFFSET | SIZE | TYPE      | DESCRIPTION
+0      | 1    | byte      | Message type (9)
+1      | 16   | bytes[16] | Command ID (UUID of the target running command)
+17     | 1    | byte      | Signal kind (0 = Interrupt / Ctrl+C, 1 = Eof / Ctrl+D)
+```
+
+**Total Size:** 18 bytes
+
+**Signal kinds:**
+- `0` — **Interrupt** (Ctrl+C): cancels the command's `CancellationTokenSource`, resulting in `process.Kill(entireProcessTree: true)` and a `StreamEnd` with `exitCode = -1`. Semantically equivalent to `CommandKill` but mapped to the keyboard event rather than an explicit "Kill" button.
+- `1` — **Eof** (Ctrl+D): closes the target process's stdin, signaling end-of-file. Lets interactive commands that read stdin (`cat`, `wc`, `python -`) exit cleanly with their normal exit code.
+
+**Notes:**
+- No response message is sent. If the `commandId` does not match an active command, the signal is silently dropped (logged server-side).
+- For a command to be interruptible/eof-able, it must be an active streaming command tracked in the client context.
+- Process stdin remains open for the full lifetime of every streaming command so that Eof has meaning at any time.
 
 ---
 

--- a/src/CtfDeck.Abstractions/Ports/Tools/IToolInstallationCoordinator.cs
+++ b/src/CtfDeck.Abstractions/Ports/Tools/IToolInstallationCoordinator.cs
@@ -9,5 +9,12 @@ public interface IToolInstallationCoordinator
     Task InstallAsync(
         IReadOnlyCollection<string> toolIds,
         Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
+        CancellationToken cancellationToken = default);
+
+    Task UninstallAsync(
+        IReadOnlyCollection<string> toolIds,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/CtfDeck.Abstractions/Ports/Tools/IToolInstaller.cs
+++ b/src/CtfDeck.Abstractions/Ports/Tools/IToolInstaller.cs
@@ -7,5 +7,12 @@ public interface IToolInstaller
     Task InstallAsync(
         ToolDefinition tool,
         Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
+        CancellationToken cancellationToken = default);
+
+    Task UninstallAsync(
+        ToolDefinition tool,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/CtfDeck.Contracts/Models/Tools/ToolInstallState.cs
+++ b/src/CtfDeck.Contracts/Models/Tools/ToolInstallState.cs
@@ -8,5 +8,6 @@ public enum ToolInstallState
     Installing = 3,
     Verifying = 4,
     Success = 5,
-    Failed = 6
+    Failed = 6,
+    Uninstalling = 7
 }

--- a/src/CtfDeck.Contracts/Models/Tools/ToolInstaller.cs
+++ b/src/CtfDeck.Contracts/Models/Tools/ToolInstaller.cs
@@ -5,10 +5,14 @@ public class ToolInstaller
     public required string Os { get; set; }
     public required string Arch { get; set; }
     public required string Type { get; set; }
-    public required string Url { get; set; }
-    public required string ArchiveType { get; set; }
-    public required string ExecutableRelativePath { get; set; }
-    public required string ExecutableName { get; set; }
+    public string? Url { get; set; }
+    public string? ArchiveType { get; set; }
+    public string? ExecutableRelativePath { get; set; }
+    public string? ExecutableName { get; set; }
+    public string? PackageManager { get; set; }
+    public string? PackageId { get; set; }
+    public string? InstallArgs { get; set; }
+    public bool? RequiresElevation { get; set; }
     public string? Version { get; set; }
     public string? Sha256 { get; set; }
 }

--- a/src/CtfDeck.Contracts/Models/Tools/ToolInstallerDto.cs
+++ b/src/CtfDeck.Contracts/Models/Tools/ToolInstallerDto.cs
@@ -5,10 +5,14 @@ public sealed class ToolInstallerDto
     public required string Os { get; init; }
     public required string Arch { get; init; }
     public required string Type { get; init; }
-    public required string Url { get; init; }
-    public required string ArchiveType { get; init; }
-    public required string ExecutableRelativePath { get; init; }
-    public required string ExecutableName { get; init; }
+    public string? Url { get; init; }
+    public string? ArchiveType { get; init; }
+    public string? ExecutableRelativePath { get; init; }
+    public string? ExecutableName { get; init; }
+    public string? PackageManager { get; init; }
+    public string? PackageId { get; init; }
+    public string? InstallArgs { get; init; }
+    public bool? RequiresElevation { get; init; }
     public string? Version { get; init; }
     public string? Sha256 { get; init; }
 }

--- a/src/CtfDeck.Contracts/Protocols/Tools/ToolProtocolDeserializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/Tools/ToolProtocolDeserializer.cs
@@ -27,10 +27,23 @@ public class ToolInstallRequest
     }
 }
 
+public class ToolUninstallRequest
+{
+    public Guid MessageId { get; }
+    public IReadOnlyList<string> ToolIds { get; }
+
+    public ToolUninstallRequest(ReadOnlySpan<byte> data)
+    {
+        var reader = new BinaryProtocolReader(data);
+        (_, MessageId) = reader.ReadHeader();
+        ToolIds = reader.ReadStringList();
+    }
+}
+
 public static class ToolProtocolDeserializer
 {
     public static bool IsToolMessage(MessageType type)
     {
-        return type >= MessageType.ToolInventoryRequest && type <= MessageType.ToolInstallProgress;
+        return type >= MessageType.ToolInventoryRequest && type <= MessageType.ToolCatalogSnapshot;
     }
 }

--- a/src/CtfDeck.Contracts/Protocols/Tools/ToolProtocolSerializer.cs
+++ b/src/CtfDeck.Contracts/Protocols/Tools/ToolProtocolSerializer.cs
@@ -11,6 +11,9 @@ public static class ToolProtocolSerializer
     public static byte[] SerializeInstallAccepted(Guid messageId, bool success)
         => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.ToolInstallAccepted, messageId, success);
 
+    public static byte[] SerializeUninstallAccepted(Guid messageId, bool success)
+        => BinaryProtocolSerializer.SerializeSimpleResult(MessageType.ToolUninstallAccepted, messageId, success);
+
     public static byte[] SerializeInstallProgress(Guid messageId, ToolInstallProgressDto progress)
     {
         using var writer = new PooledBufferWriter();

--- a/src/CtfDeck.Contracts/Transport/MessageType.cs
+++ b/src/CtfDeck.Contracts/Transport/MessageType.cs
@@ -15,6 +15,7 @@ public enum MessageType : byte
     CommandExecute = 6,
     PasswordRequest = 7,    // Server -> Client
     PasswordProvide = 8,    // Client -> Server
+    CommandSignal = 9,      // Client -> Server (Ctrl+C / Ctrl+D, fire-and-forget)
 
     // Session requests (client → server)
     SessionCreate = 10,

--- a/src/CtfDeck.Contracts/Transport/MessageType.cs
+++ b/src/CtfDeck.Contracts/Transport/MessageType.cs
@@ -125,11 +125,13 @@ public enum MessageType : byte
     // Tool requests
     ToolInventoryRequest = 120,
     ToolInstallRequest = 121,
+    ToolUninstallRequest = 122,
 
     // Tool responses
     ToolInventoryResult = 130,
     ToolInstallAccepted = 131,
     ToolInstallProgress = 132,
+    ToolUninstallAccepted = 133,
     ToolOperationError = 139,
     ToolCatalogSnapshot = 140
 }

--- a/src/CtfDeck.Contracts/Transport/MessageType.cs
+++ b/src/CtfDeck.Contracts/Transport/MessageType.cs
@@ -16,6 +16,7 @@ public enum MessageType : byte
     PasswordRequest = 7,    // Server -> Client
     PasswordProvide = 8,    // Client -> Server
     CommandSignal = 9,      // Client -> Server (Ctrl+C / Ctrl+D, fire-and-forget)
+    CommandInput = 150,     // Client -> Server (Raw stdin text)
 
     // Session requests (client → server)
     SessionCreate = 10,

--- a/src/CtfDeck.Contracts/Transport/TerminalProtocol.cs
+++ b/src/CtfDeck.Contracts/Transport/TerminalProtocol.cs
@@ -164,6 +164,26 @@ public readonly ref struct CommandKillReader
     }
 }
 
+public enum CommandSignalKind : byte
+{
+    Interrupt = 0,
+    Eof = 1
+}
+
+public readonly ref struct CommandSignalReader
+{
+    public readonly Guid CommandId;
+    public readonly CommandSignalKind Kind;
+
+    public CommandSignalReader(ReadOnlySpan<byte> data)
+    {
+        var reader = new BinaryProtocolReader(data);
+        reader.ReadByte(); // type: CommandSignal (9)
+        CommandId = reader.ReadGuid();
+        Kind = (CommandSignalKind)reader.ReadByte();
+    }
+}
+
 public readonly ref struct PasswordProvideReader
 {
     public readonly Guid MessageId;

--- a/src/CtfDeck.Contracts/Transport/TerminalProtocol.cs
+++ b/src/CtfDeck.Contracts/Transport/TerminalProtocol.cs
@@ -200,6 +200,19 @@ public readonly ref struct PasswordProvideReader
     public string GetPassword() => Password;
 }
 
+public readonly ref struct CommandInputReader
+{
+    public readonly Guid MessageId;
+    public readonly string Input;
+
+    public CommandInputReader(ReadOnlySpan<byte> data)
+    {
+        var reader = new BinaryProtocolReader(data);
+        (_, MessageId) = reader.ReadHeader();
+        Input = reader.ReadString();
+    }
+}
+
 public readonly ref struct TerminalStreamChunk
 {
     public readonly MessageType Type;

--- a/src/CtfDeck.Terminal/Features/Tools/ArchiveExtractor.cs
+++ b/src/CtfDeck.Terminal/Features/Tools/ArchiveExtractor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Formats.Tar;
 using System.IO.Compression;
 
@@ -24,6 +25,45 @@ public class ArchiveExtractor
                 await using (var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress))
                 {
                     TarFile.ExtractToDirectory(gzipStream, destinationDirectory, overwriteFiles: true);
+                }
+                break;
+
+            case "7z":
+                if (OperatingSystem.IsWindows())
+                {
+                    using var process = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "tar",
+                        Arguments = $"-xf \"{archivePath}\" -C \"{destinationDirectory}\"",
+                        CreateNoWindow = true,
+                        UseShellExecute = false
+                    });
+                    if (process is not null)
+                    {
+                        await process.WaitForExitAsync(cancellationToken);
+                        if (process.ExitCode != 0)
+                        {
+                            throw new InvalidOperationException($"Tar extraction of .7z failed with exit code {process.ExitCode}");
+                        }
+                    }
+                }
+                else
+                {
+                    using var process = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "7z",
+                        Arguments = $"x \"{archivePath}\" -o\"{destinationDirectory}\" -y",
+                        CreateNoWindow = true,
+                        UseShellExecute = false
+                    });
+                    if (process is not null)
+                    {
+                        await process.WaitForExitAsync(cancellationToken);
+                        if (process.ExitCode != 0)
+                        {
+                            throw new InvalidOperationException($"7z extraction failed with exit code {process.ExitCode}");
+                        }
+                    }
                 }
                 break;
 

--- a/src/CtfDeck.Terminal/Features/Tools/PlatformInfoProvider.cs
+++ b/src/CtfDeck.Terminal/Features/Tools/PlatformInfoProvider.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+using CtfDeck.Abstractions.Ports.Tools;
+
+namespace CtfDeck.Terminal.Features.Tools;
+
+public sealed class PlatformInfoProvider : IPlatformInfoProvider
+{
+    public string GetOs()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "windows";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "macos";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "linux";
+        throw new PlatformNotSupportedException("Unsupported OS.");
+    }
+
+    public string GetArch()
+    {
+        return RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            _ => throw new PlatformNotSupportedException($"Unsupported architecture: {RuntimeInformation.OSArchitecture}")
+        };
+    }
+}

--- a/src/CtfDeck.Terminal/Features/Tools/ToolCatalogService.cs
+++ b/src/CtfDeck.Terminal/Features/Tools/ToolCatalogService.cs
@@ -92,13 +92,32 @@ public class ToolCatalogService : IToolCatalogProvider
             {
                 if (string.IsNullOrWhiteSpace(installer.Os) ||
                     string.IsNullOrWhiteSpace(installer.Arch) ||
-                    string.IsNullOrWhiteSpace(installer.Type) ||
-                    string.IsNullOrWhiteSpace(installer.Url) ||
-                    string.IsNullOrWhiteSpace(installer.ArchiveType) ||
-                    string.IsNullOrWhiteSpace(installer.ExecutableRelativePath) ||
-                    string.IsNullOrWhiteSpace(installer.ExecutableName))
+                    string.IsNullOrWhiteSpace(installer.Type))
                 {
                     throw new InvalidOperationException($"Tool '{tool.Id}' contains an invalid installer.");
+                }
+
+                if (installer.Type.Equals("archive", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (string.IsNullOrWhiteSpace(installer.Url) ||
+                        string.IsNullOrWhiteSpace(installer.ArchiveType) ||
+                        string.IsNullOrWhiteSpace(installer.ExecutableRelativePath) ||
+                        string.IsNullOrWhiteSpace(installer.ExecutableName))
+                    {
+                        throw new InvalidOperationException($"Tool '{tool.Id}' contains an invalid archive installer.");
+                    }
+                }
+                else if (installer.Type.Equals("packageManager", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (string.IsNullOrWhiteSpace(installer.PackageManager) ||
+                        string.IsNullOrWhiteSpace(installer.PackageId))
+                    {
+                        throw new InvalidOperationException($"Tool '{tool.Id}' contains an invalid package manager installer.");
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Tool '{tool.Id}' has unsupported installer type '{installer.Type}'.");
                 }
             }
         }

--- a/src/CtfDeck.Terminal/Features/Tools/ToolDetectionService.cs
+++ b/src/CtfDeck.Terminal/Features/Tools/ToolDetectionService.cs
@@ -174,7 +174,26 @@ public class ToolDetectionService : IToolDetector
         {
             var machinePath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine) ?? "";
             var userPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? "";
-            var combinedPath = $"{machinePath}{Path.PathSeparator}{userPath}";
+            var processPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process) ?? "";
+
+            var separators = new[] { Path.PathSeparator };
+            var allPaths = new List<string>();
+
+            var processDirs = processPath.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            var machineDirs = machinePath.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            var userDirs = userPath.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var dir in processDirs.Concat(machineDirs).Concat(userDirs))
+            {
+                var trimmed = dir.Trim();
+                if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
+                {
+                    allPaths.Add(trimmed);
+                }
+            }
+
+            var combinedPath = string.Join(Path.PathSeparator, allPaths);
             Environment.SetEnvironmentVariable("PATH", combinedPath, EnvironmentVariableTarget.Process);
         }
         catch

--- a/src/CtfDeck.Terminal/Features/Tools/ToolDetectionService.cs
+++ b/src/CtfDeck.Terminal/Features/Tools/ToolDetectionService.cs
@@ -8,13 +8,16 @@ public class ToolDetectionService : IToolDetector
 {
     private readonly IToolCatalogProvider _toolCatalogProvider;
     private readonly IToolPathResolver _toolPathResolver;
+    private readonly IPlatformInfoProvider _platformInfoProvider;
 
     public ToolDetectionService(
         IToolCatalogProvider toolCatalogProvider,
-        IToolPathResolver toolPathResolver)
+        IToolPathResolver toolPathResolver,
+        IPlatformInfoProvider platformInfoProvider)
     {
         _toolCatalogProvider = toolCatalogProvider;
         _toolPathResolver = toolPathResolver;
+        _platformInfoProvider = platformInfoProvider;
     }
 
     public async Task<IReadOnlyCollection<ToolStatusDto>> DetectAllAsync(CancellationToken cancellationToken = default)
@@ -57,11 +60,12 @@ public class ToolDetectionService : IToolDetector
         }
 
         var installer = ResolveInstaller(tool);
-        var isInstallable = installer is not null;
+        var isInstallable = IsInstallable(installer);
 
         if (installer is not null)
         {
-            var localPath = _toolPathResolver.GetToolExecutablePath(tool.Id, installer.ExecutableName);
+            var exeName = installer.ExecutableName ?? tool.CheckCommand ?? tool.Id;
+            var localPath = _toolPathResolver.GetToolExecutablePath(tool.Id, exeName);
             if (File.Exists(localPath))
             {
                 return new ToolStatusDto
@@ -71,7 +75,7 @@ public class ToolDetectionService : IToolDetector
                     Description = tool.Description,
                     Kind = tool.Kind,
                     IsInstalled = true,
-                    IsInstallable = true,
+                    IsInstallable = isInstallable,
                     InstalledPath = localPath,
                     Version = installer.Version,
                     Reason = null
@@ -108,42 +112,80 @@ public class ToolDetectionService : IToolDetector
             IsInstallable = isInstallable,
             InstalledPath = null,
             Version = installer?.Version,
-            Reason = isInstallable
-                ? "Tool not found locally or in PATH."
-                : $"No installer available for {GetCurrentOs()}/{GetCurrentArch()}."
+            Reason = BuildMissingReason(installer)
         };
     }
 
-    private static ToolInstaller? ResolveInstaller(ToolDefinition tool)
+    private ToolInstaller? ResolveInstaller(ToolDefinition tool)
     {
-        var os = GetCurrentOs();
-        var arch = GetCurrentArch();
+        var os = _platformInfoProvider.GetOs();
+        var arch = _platformInfoProvider.GetArch();
 
-        return tool.Installers.FirstOrDefault(i =>
+        var matches = tool.Installers.Where(i =>
             i.Os.Equals(os, StringComparison.OrdinalIgnoreCase) &&
-            i.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase));
+            i.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (matches.Count == 0)
+            return null;
+
+        var pmMatch = matches.FirstOrDefault(i =>
+            i.Type.Equals("packageManager", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(i.PackageManager) &&
+            FindExecutableInPath(i.PackageManager) is not null);
+
+        return pmMatch ?? matches.First();
     }
 
-    private static string GetCurrentOs()
+    private bool IsInstallable(ToolInstaller? installer)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "windows";
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "macos";
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "linux";
-        throw new PlatformNotSupportedException("Unsupported OS.");
+        if (installer is null)
+            return false;
+
+        if (!installer.Type.Equals("packageManager", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (string.IsNullOrWhiteSpace(installer.PackageManager))
+            return false;
+
+        return FindExecutableInPath(installer.PackageManager) is not null;
     }
 
-    private static string GetCurrentArch()
+    private string BuildMissingReason(ToolInstaller? installer)
     {
-        return RuntimeInformation.OSArchitecture switch
+        if (installer is null)
+            return $"No installer available for {_platformInfoProvider.GetOs()}/{_platformInfoProvider.GetArch()}.";
+
+        if (installer.Type.Equals("packageManager", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(installer.PackageManager) &&
+            FindExecutableInPath(installer.PackageManager) is null)
         {
-            Architecture.X64 => "x64",
-            Architecture.Arm64 => "arm64",
-            _ => throw new PlatformNotSupportedException($"Unsupported architecture: {RuntimeInformation.OSArchitecture}")
-        };
+            return $"Required package manager '{installer.PackageManager}' is not available in PATH.";
+        }
+
+        return "Tool not found locally or in PATH.";
+    }
+
+    private static void RefreshPathEnvironmentVariable()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            var machinePath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine) ?? "";
+            var userPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? "";
+            var combinedPath = $"{machinePath}{Path.PathSeparator}{userPath}";
+            Environment.SetEnvironmentVariable("PATH", combinedPath, EnvironmentVariableTarget.Process);
+        }
+        catch
+        {
+            // Ignore registry reading or assignment errors
+        }
     }
 
     private static string? FindExecutableInPath(string executableName)
     {
+        RefreshPathEnvironmentVariable();
         var path = Environment.GetEnvironmentVariable("PATH");
         if (string.IsNullOrWhiteSpace(path))
             return null;

--- a/src/CtfDeck.Terminal/Features/Tools/ToolInstallationCoordinator.cs
+++ b/src/CtfDeck.Terminal/Features/Tools/ToolInstallationCoordinator.cs
@@ -25,6 +25,7 @@ public class ToolInstallationCoordinator : IToolInstallationCoordinator
     public async Task InstallAsync(
         IReadOnlyCollection<string> toolIds,
         Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
         CancellationToken cancellationToken = default)
     {
         foreach (var toolId in toolIds.Distinct(StringComparer.OrdinalIgnoreCase))
@@ -43,7 +44,33 @@ public class ToolInstallationCoordinator : IToolInstallationCoordinator
                 continue;
             }
 
-            await _toolInstaller.InstallAsync(tool, progressCallback, cancellationToken);
+            await _toolInstaller.InstallAsync(tool, progressCallback, requestSecretAsync, cancellationToken);
+        }
+    }
+
+    public async Task UninstallAsync(
+        IReadOnlyCollection<string> toolIds,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var toolId in toolIds.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var tool = await _toolCatalogProvider.GetByIdAsync(toolId, cancellationToken);
+
+            if (tool is null)
+            {
+                await progressCallback(new ToolInstallProgressDto
+                {
+                    ToolId = toolId,
+                    State = ToolInstallState.Failed,
+                    Message = "Unknown tool.",
+                    Error = $"Unknown tool '{toolId}'."
+                });
+                continue;
+            }
+
+            await _toolInstaller.UninstallAsync(tool, progressCallback, requestSecretAsync, cancellationToken);
         }
     }
 }

--- a/src/CtfDeck.Terminal/Features/Tools/ToolInstallationService.cs
+++ b/src/CtfDeck.Terminal/Features/Tools/ToolInstallationService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using System.Security.Principal;
 using CtfDeck.Abstractions.Ports.Tools;
 using CtfDeck.Contracts.Models.Tools;
 
@@ -10,18 +11,22 @@ public class ToolInstallationService : IToolInstaller
 {
     private readonly IToolPathResolver _toolPathResolver;
     private readonly ArchiveExtractor _archiveExtractor;
+    private readonly IPlatformInfoProvider _platformInfoProvider;
 
     public ToolInstallationService(
         IToolPathResolver toolPathResolver,
-        ArchiveExtractor archiveExtractor)
+        ArchiveExtractor archiveExtractor,
+        IPlatformInfoProvider platformInfoProvider)
     {
         _toolPathResolver = toolPathResolver;
         _archiveExtractor = archiveExtractor;
+        _platformInfoProvider = platformInfoProvider;
     }
 
     public async Task InstallAsync(
         ToolDefinition tool,
         Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -35,97 +40,14 @@ public class ToolInstallationService : IToolInstaller
                 Message = "Preparing installation."
             });
 
-            var installDirectory = _toolPathResolver.GetToolInstallDirectory(tool.Id);
-            var binDirectory = _toolPathResolver.GetToolsBinDirectory();
-            var workDirectory = _toolPathResolver.GetToolWorkingDirectory(tool.Id);
-
-            if (Directory.Exists(workDirectory))
-                Directory.Delete(workDirectory, true);
-
-            Directory.CreateDirectory(workDirectory);
-            Directory.CreateDirectory(installDirectory);
-            Directory.CreateDirectory(binDirectory);
-
-            var downloadFilePath = Path.Combine(workDirectory, GetDownloadFileName(installer));
-
-            await progressCallback(new ToolInstallProgressDto
+            if (installer.Type.Equals("packageManager", StringComparison.OrdinalIgnoreCase))
             {
-                ToolId = tool.Id,
-                State = ToolInstallState.Downloading,
-                Message = "Downloading package.",
-                ProgressPercent = 0
-            });
-
-            await DownloadFileAsync(installer.Url, downloadFilePath, async percent =>
-            {
-                await progressCallback(new ToolInstallProgressDto
-                {
-                    ToolId = tool.Id,
-                    State = ToolInstallState.Downloading,
-                    Message = "Downloading package.",
-                    ProgressPercent = percent
-                });
-            }, cancellationToken);
-
-            if (!string.IsNullOrWhiteSpace(installer.Sha256))
-            {
-                var actualHash = await ComputeSha256Async(downloadFilePath, cancellationToken);
-                if (!actualHash.Equals(installer.Sha256, StringComparison.OrdinalIgnoreCase))
-                    throw new InvalidOperationException("Downloaded file checksum mismatch.");
+                await InstallWithPackageManagerAsync(tool, installer, progressCallback, requestSecretAsync, cancellationToken);
             }
-
-            var extractionDirectory = Path.Combine(workDirectory, "extracted");
-            Directory.CreateDirectory(extractionDirectory);
-
-            if (!installer.ArchiveType.Equals("none", StringComparison.OrdinalIgnoreCase))
+            else
             {
-                await progressCallback(new ToolInstallProgressDto
-                {
-                    ToolId = tool.Id,
-                    State = ToolInstallState.Extracting,
-                    Message = "Extracting package."
-                });
-
-                await _archiveExtractor.ExtractAsync(downloadFilePath, extractionDirectory, installer.ArchiveType, cancellationToken);
+                await InstallWithArchiveAsync(tool, installer, progressCallback, cancellationToken);
             }
-
-            await progressCallback(new ToolInstallProgressDto
-            {
-                ToolId = tool.Id,
-                State = ToolInstallState.Installing,
-                Message = "Installing binary."
-            });
-
-            var sourceBinaryPath = ResolveSourceBinaryPath(installer, downloadFilePath, extractionDirectory);
-            var targetBinaryPath = _toolPathResolver.GetToolExecutablePath(tool.Id, installer.ExecutableName);
-
-            if (File.Exists(targetBinaryPath))
-                File.Delete(targetBinaryPath);
-
-            File.Copy(sourceBinaryPath, targetBinaryPath, true);
-
-            if (!OperatingSystem.IsWindows())
-                await MakeExecutableAsync(targetBinaryPath, cancellationToken);
-
-            await progressCallback(new ToolInstallProgressDto
-            {
-                ToolId = tool.Id,
-                State = ToolInstallState.Verifying,
-                Message = "Verifying installation."
-            });
-
-            var verified = await VerifyAsync(targetBinaryPath, tool.CheckArguments ?? "--help", cancellationToken);
-            if (!verified)
-                throw new InvalidOperationException("Installed binary verification failed or timed out.");
-
-            await progressCallback(new ToolInstallProgressDto
-            {
-                ToolId = tool.Id,
-                State = ToolInstallState.Success,
-                Message = "Installation completed.",
-                ProgressPercent = 100,
-                InstalledPath = targetBinaryPath
-            });
         }
         catch (Exception ex)
         {
@@ -139,23 +61,534 @@ public class ToolInstallationService : IToolInstaller
         }
     }
 
-    private static ToolInstaller ResolveInstaller(ToolDefinition tool)
+    public async Task UninstallAsync(
+        ToolDefinition tool,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
+        CancellationToken cancellationToken = default)
     {
-        var os = GetCurrentOs();
-        var arch = GetCurrentArch();
+        try
+        {
+            var installer = ResolveInstaller(tool);
 
-        return tool.Installers.FirstOrDefault(i =>
-                   i.Os.Equals(os, StringComparison.OrdinalIgnoreCase) &&
-                   i.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase))
-               ?? throw new InvalidOperationException($"No installer available for '{tool.Id}' on {os}/{arch}.");
+            await progressCallback(new ToolInstallProgressDto
+            {
+                ToolId = tool.Id,
+                State = ToolInstallState.Uninstalling,
+                Message = "Preparing uninstallation."
+            });
+
+            if (installer.Type.Equals("packageManager", StringComparison.OrdinalIgnoreCase))
+            {
+                await UninstallWithPackageManagerAsync(tool, installer, progressCallback, requestSecretAsync, cancellationToken);
+            }
+            else
+            {
+                await UninstallWithArchiveAsync(tool, installer, progressCallback, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            await progressCallback(new ToolInstallProgressDto
+            {
+                ToolId = tool.Id,
+                State = ToolInstallState.Failed,
+                Message = "Uninstallation failed.",
+                Error = ex.Message
+            });
+        }
+    }
+
+    private async Task UninstallWithArchiveAsync(
+        ToolDefinition tool,
+        ToolInstaller installer,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        CancellationToken cancellationToken)
+    {
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Uninstalling,
+            Message = "Deleting binary and directories."
+        });
+
+        var targetBinaryPath = _toolPathResolver.GetToolExecutablePath(tool.Id, installer.ExecutableName ?? tool.Id);
+        if (File.Exists(targetBinaryPath))
+        {
+            File.Delete(targetBinaryPath);
+        }
+
+        var workDirectory = _toolPathResolver.GetToolWorkingDirectory(tool.Id);
+        if (Directory.Exists(workDirectory))
+        {
+            Directory.Delete(workDirectory, true);
+        }
+
+        var installDirectory = _toolPathResolver.GetToolInstallDirectory(tool.Id);
+        if (Directory.Exists(installDirectory))
+        {
+            Directory.Delete(installDirectory, true);
+        }
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Success,
+            Message = "Uninstallation completed.",
+            ProgressPercent = 100
+        });
+    }
+
+    private async Task UninstallWithPackageManagerAsync(
+        ToolDefinition tool,
+        ToolInstaller installer,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(installer.PackageManager) || string.IsNullOrWhiteSpace(installer.PackageId))
+            throw new InvalidOperationException("Package manager installer is missing required fields.");
+
+        var pmPath = FindExecutableInPath(installer.PackageManager);
+        if (pmPath is null)
+            throw new InvalidOperationException($"Package manager '{installer.PackageManager}' is not available in PATH.");
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Uninstalling,
+            Message = $"Uninstalling with {installer.PackageManager}."
+        });
+
+        var needsElevation = installer.RequiresElevation ?? !OperatingSystem.IsWindows();
+        var useSudo = needsElevation && !OperatingSystem.IsWindows() && !IsRunningAsRoot();
+        var useWindowsUac = OperatingSystem.IsWindows() && needsElevation && !IsWindowsAdministrator();
+
+        var (fileName, arguments) = BuildUninstallCommand(installer);
+
+        string? sudoPassword = null;
+        if (useSudo)
+        {
+            if (requestSecretAsync is null)
+                throw new InvalidOperationException("Sudo password callback is unavailable.");
+
+            sudoPassword = await requestSecretAsync("Sudo password required to uninstall tool", cancellationToken);
+            if (string.IsNullOrEmpty(sudoPassword))
+                throw new OperationCanceledException("Sudo password not provided");
+        }
+
+        int exitCode;
+        if (useWindowsUac)
+        {
+            await progressCallback(new ToolInstallProgressDto
+            {
+                ToolId = tool.Id,
+                State = ToolInstallState.Uninstalling,
+                Message = "Requesting administrator privileges (UAC)..."
+            });
+            exitCode = await ExecuteCommandElevatedWindowsAsync(fileName, arguments, cancellationToken);
+        }
+        else
+        {
+            exitCode = await ExecuteCommandAsync(fileName, arguments, useSudo, sudoPassword, cancellationToken);
+        }
+
+        if (exitCode != 0)
+            throw new InvalidOperationException($"Package manager uninstall failed with exit code {exitCode}.");
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Success,
+            Message = "Uninstallation completed.",
+            ProgressPercent = 100
+        });
+    }
+
+    private async Task InstallWithArchiveAsync(
+        ToolDefinition tool,
+        ToolInstaller installer,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(installer.Url) ||
+            string.IsNullOrWhiteSpace(installer.ArchiveType) ||
+            string.IsNullOrWhiteSpace(installer.ExecutableName) ||
+            string.IsNullOrWhiteSpace(installer.ExecutableRelativePath))
+        {
+            throw new InvalidOperationException("Archive installer is missing required fields.");
+        }
+
+        var installDirectory = _toolPathResolver.GetToolInstallDirectory(tool.Id);
+        var binDirectory = _toolPathResolver.GetToolsBinDirectory();
+        var workDirectory = _toolPathResolver.GetToolWorkingDirectory(tool.Id);
+
+        if (Directory.Exists(workDirectory))
+            Directory.Delete(workDirectory, true);
+
+        Directory.CreateDirectory(workDirectory);
+        Directory.CreateDirectory(installDirectory);
+        Directory.CreateDirectory(binDirectory);
+
+        var downloadFilePath = Path.Combine(workDirectory, GetDownloadFileName(installer));
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Downloading,
+            Message = "Downloading package.",
+            ProgressPercent = 0
+        });
+
+        await DownloadFileAsync(installer.Url, downloadFilePath, async percent =>
+        {
+            await progressCallback(new ToolInstallProgressDto
+            {
+                ToolId = tool.Id,
+                State = ToolInstallState.Downloading,
+                Message = "Downloading package.",
+                ProgressPercent = percent
+            });
+        }, cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(installer.Sha256))
+        {
+            var actualHash = await ComputeSha256Async(downloadFilePath, cancellationToken);
+            if (!actualHash.Equals(installer.Sha256, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Downloaded file checksum mismatch.");
+        }
+
+        var extractionDirectory = Path.Combine(workDirectory, "extracted");
+        Directory.CreateDirectory(extractionDirectory);
+
+        if (!installer.ArchiveType.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            await progressCallback(new ToolInstallProgressDto
+            {
+                ToolId = tool.Id,
+                State = ToolInstallState.Extracting,
+                Message = "Extracting package."
+            });
+
+            await _archiveExtractor.ExtractAsync(downloadFilePath, extractionDirectory, installer.ArchiveType, cancellationToken);
+        }
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Installing,
+            Message = "Installing binary."
+        });
+
+        var sourceBinaryPath = ResolveSourceBinaryPath(installer, downloadFilePath, extractionDirectory);
+        var targetBinaryPath = _toolPathResolver.GetToolExecutablePath(tool.Id, installer.ExecutableName);
+
+        if (File.Exists(targetBinaryPath))
+            File.Delete(targetBinaryPath);
+
+        File.Copy(sourceBinaryPath, targetBinaryPath, true);
+
+        if (!OperatingSystem.IsWindows())
+            await MakeExecutableAsync(targetBinaryPath, cancellationToken);
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Verifying,
+            Message = "Verifying installation."
+        });
+
+        var verified = await VerifyAsync(targetBinaryPath, tool.CheckArguments ?? "--help", cancellationToken);
+        if (!verified)
+            throw new InvalidOperationException("Installed binary verification failed or timed out.");
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Success,
+            Message = "Installation completed.",
+            ProgressPercent = 100,
+            InstalledPath = targetBinaryPath
+        });
+    }
+
+    private async Task InstallWithPackageManagerAsync(
+        ToolDefinition tool,
+        ToolInstaller installer,
+        Func<ToolInstallProgressDto, Task> progressCallback,
+        Func<string, CancellationToken, Task<string?>>? requestSecretAsync,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(installer.PackageManager) || string.IsNullOrWhiteSpace(installer.PackageId))
+            throw new InvalidOperationException("Package manager installer is missing required fields.");
+
+        var pmPath = FindExecutableInPath(installer.PackageManager);
+        if (pmPath is null)
+            throw new InvalidOperationException($"Package manager '{installer.PackageManager}' is not available in PATH.");
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Installing,
+            Message = $"Installing with {installer.PackageManager}."
+        });
+
+        var needsElevation = installer.RequiresElevation ?? !OperatingSystem.IsWindows();
+        var useSudo = needsElevation && !OperatingSystem.IsWindows() && !IsRunningAsRoot();
+        var useWindowsUac = OperatingSystem.IsWindows() && needsElevation && !IsWindowsAdministrator();
+
+        var (fileName, arguments) = BuildInstallCommand(installer);
+        if (!string.IsNullOrWhiteSpace(installer.InstallArgs))
+            arguments = $"{arguments} {installer.InstallArgs}";
+
+        string? sudoPassword = null;
+        if (useSudo)
+        {
+            if (requestSecretAsync is null)
+                throw new InvalidOperationException("Sudo password callback is unavailable.");
+
+            sudoPassword = await requestSecretAsync("Sudo password required to install tool", cancellationToken);
+            if (string.IsNullOrEmpty(sudoPassword))
+                throw new OperationCanceledException("Sudo password not provided");
+        }
+
+        int exitCode;
+        if (useWindowsUac)
+        {
+            await progressCallback(new ToolInstallProgressDto
+            {
+                ToolId = tool.Id,
+                State = ToolInstallState.Installing,
+                Message = "Requesting administrator privileges (UAC)..."
+            });
+            exitCode = await ExecuteCommandElevatedWindowsAsync(fileName, arguments, cancellationToken);
+        }
+        else
+        {
+            exitCode = await ExecuteCommandAsync(fileName, arguments, useSudo, sudoPassword, cancellationToken);
+        }
+        if (exitCode != 0)
+            throw new InvalidOperationException($"Package manager install failed with exit code {exitCode}.");
+
+        var checkCommand = tool.CheckCommand ?? tool.Id;
+        var installedPath = FindExecutableInPath(checkCommand);
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Verifying,
+            Message = "Verifying installation."
+        });
+
+        if (installedPath is null)
+            throw new InvalidOperationException("Tool is not available in PATH after installation.");
+
+        var verified = await VerifyAsync(installedPath, tool.CheckArguments ?? "--help", cancellationToken);
+        if (!verified)
+            throw new InvalidOperationException("Installed tool verification failed or timed out.");
+
+        await progressCallback(new ToolInstallProgressDto
+        {
+            ToolId = tool.Id,
+            State = ToolInstallState.Success,
+            Message = "Installation completed.",
+            ProgressPercent = 100,
+            InstalledPath = installedPath
+        });
+    }
+
+    private ToolInstaller ResolveInstaller(ToolDefinition tool)
+    {
+        var os = _platformInfoProvider.GetOs();
+        var arch = _platformInfoProvider.GetArch();
+
+        var matches = tool.Installers
+            .Where(i => i.Os.Equals(os, StringComparison.OrdinalIgnoreCase) &&
+                        i.Arch.Equals(arch, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 0)
+            throw new InvalidOperationException($"No installer available for '{tool.Id}' on {os}/{arch}.");
+
+        var pmMatch = matches.FirstOrDefault(i =>
+            i.Type.Equals("packageManager", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(i.PackageManager) &&
+            FindExecutableInPath(i.PackageManager) is not null);
+
+        return pmMatch ?? matches.First();
+    }
+
+    private static (string fileName, string arguments) BuildInstallCommand(ToolInstaller installer)
+    {
+        var pm = installer.PackageManager!.ToLowerInvariant();
+        var packageId = installer.PackageId!;
+
+        return pm switch
+        {
+            "winget" => ("winget", $"install --id {packageId} --accept-source-agreements --accept-package-agreements --silent"),
+            "apt" => ("apt-get", $"install -y {packageId}"),
+            "dnf" => ("dnf", $"install -y {packageId}"),
+            "pacman" => ("pacman", $"-Sy --noconfirm {packageId}"),
+            "brew" => ("brew", $"install {packageId}"),
+            _ => throw new InvalidOperationException($"Unsupported package manager '{installer.PackageManager}'.")
+        };
+    }
+
+    private static (string fileName, string arguments) BuildUninstallCommand(ToolInstaller installer)
+    {
+        var pm = installer.PackageManager!.ToLowerInvariant();
+        var packageId = installer.PackageId!;
+
+        return pm switch
+        {
+            "winget" => ("winget", $"uninstall --id {packageId} --silent"),
+            "apt" => ("apt-get", $"remove -y {packageId}"),
+            "dnf" => ("dnf", $"remove -y {packageId}"),
+            "pacman" => ("pacman", $"-R --noconfirm {packageId}"),
+            "brew" => ("brew", $"uninstall {packageId}"),
+            _ => throw new InvalidOperationException($"Unsupported package manager '{installer.PackageManager}'.")
+        };
+    }
+
+    private static async Task<int> ExecuteCommandAsync(
+        string fileName,
+        string arguments,
+        bool useSudo,
+        string? sudoPassword,
+        CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = useSudo ? "sudo" : fileName,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            RedirectStandardInput = useSudo,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (useSudo)
+        {
+            psi.ArgumentList.Add("-S");
+            psi.ArgumentList.Add("-p");
+            psi.ArgumentList.Add("");
+            psi.ArgumentList.Add(fileName);
+            foreach (var arg in SplitArgs(arguments))
+                psi.ArgumentList.Add(arg);
+        }
+        else
+        {
+            foreach (var arg in SplitArgs(arguments))
+                psi.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException("Unable to start install process.");
+
+        if (useSudo && !string.IsNullOrEmpty(sudoPassword))
+        {
+            await process.StandardInput.WriteLineAsync(sudoPassword);
+            await process.StandardInput.FlushAsync();
+        }
+
+        await process.WaitForExitAsync(cancellationToken);
+        return process.ExitCode;
+    }
+
+    private static async Task<int> ExecuteCommandElevatedWindowsAsync(
+        string fileName,
+        string arguments,
+        CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = true,
+            Verb = "runas"
+        };
+
+        try
+        {
+            using var process = Process.Start(psi) ?? throw new InvalidOperationException("Unable to start elevated install process.");
+            await process.WaitForExitAsync(cancellationToken);
+            return process.ExitCode;
+        }
+        catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 1223) // ERROR_CANCELLED
+        {
+            throw new OperationCanceledException("UAC elevation request was canceled by the user.", ex);
+        }
+    }
+
+    private static void RefreshPathEnvironmentVariable()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            var machinePath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine) ?? "";
+            var userPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? "";
+            var combinedPath = $"{machinePath}{Path.PathSeparator}{userPath}";
+            Environment.SetEnvironmentVariable("PATH", combinedPath, EnvironmentVariableTarget.Process);
+        }
+        catch
+        {
+            // Ignore registry reading or assignment errors
+        }
+    }
+
+    private static IEnumerable<string> SplitArgs(string arguments)
+    {
+        return arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static bool IsWindowsAdministrator()
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+
+        using var identity = WindowsIdentity.GetCurrent();
+        var principal = new WindowsPrincipal(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+    }
+
+    private static bool IsRunningAsRoot()
+    {
+        return OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()
+            ? string.Equals(Environment.UserName, "root", StringComparison.Ordinal)
+            : false;
+    }
+
+    private static string? FindExecutableInPath(string executableName)
+    {
+        RefreshPathEnvironmentVariable();
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { executableName, $"{executableName}.exe" }
+            : new[] { executableName };
+
+        foreach (var dir in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var candidate in candidates)
+            {
+                var fullPath = Path.Combine(dir.Trim(), candidate);
+                if (File.Exists(fullPath))
+                    return fullPath;
+            }
+        }
+
+        return null;
     }
 
     private static string ResolveSourceBinaryPath(ToolInstaller installer, string downloadFilePath, string extractionDirectory)
     {
-        if (installer.ArchiveType.Equals("none", StringComparison.OrdinalIgnoreCase))
+        if (installer.ArchiveType!.Equals("none", StringComparison.OrdinalIgnoreCase))
             return downloadFilePath;
 
-        var path = Path.Combine(extractionDirectory, installer.ExecutableRelativePath.Replace('/', Path.DirectorySeparatorChar));
+        var path = Path.Combine(extractionDirectory, installer.ExecutableRelativePath!.Replace('/', Path.DirectorySeparatorChar));
         if (!File.Exists(path))
             throw new FileNotFoundException($"Executable not found after extraction: {path}");
 
@@ -164,11 +597,11 @@ public class ToolInstallationService : IToolInstaller
 
     private static string GetDownloadFileName(ToolInstaller installer)
     {
-        return installer.ArchiveType.ToLowerInvariant() switch
+        return installer.ArchiveType!.ToLowerInvariant() switch
         {
             "zip" => "package.zip",
             "tar.gz" => "package.tar.gz",
-            "none" => installer.ExecutableName,
+            "none" => installer.ExecutableName!,
             _ => "package.bin"
         };
     }
@@ -284,23 +717,5 @@ public class ToolInstallationService : IToolInstaller
 
             return false;
         }
-    }
-
-    private static string GetCurrentOs()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "windows";
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "macos";
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "linux";
-        throw new PlatformNotSupportedException("Unsupported OS.");
-    }
-
-    private static string GetCurrentArch()
-    {
-        return RuntimeInformation.OSArchitecture switch
-        {
-            Architecture.X64 => "x64",
-            Architecture.Arm64 => "arm64",
-            _ => throw new PlatformNotSupportedException($"Unsupported architecture: {RuntimeInformation.OSArchitecture}")
-        };
     }
 }

--- a/src/CtfDeck.Terminal/Handlers/ToolMessageHandler.cs
+++ b/src/CtfDeck.Terminal/Handlers/ToolMessageHandler.cs
@@ -7,15 +7,19 @@ namespace CtfDeck.Terminal.Handlers;
 public class ToolMessageHandler : MessageHandlerBase
 {
     private readonly IToolInstallationCoordinator _toolInstallationCoordinator;
+    private readonly Func<string, string, CancellationToken, Task<string?>>? _requestSecretAsync;
 
-    public ToolMessageHandler(IToolInstallationCoordinator toolInstallationCoordinator)
+    public ToolMessageHandler(
+        IToolInstallationCoordinator toolInstallationCoordinator,
+        Func<string, string, CancellationToken, Task<string?>>? requestSecretAsync = null)
     {
         _toolInstallationCoordinator = toolInstallationCoordinator;
+        _requestSecretAsync = requestSecretAsync;
     }
 
     protected override bool CanHandle(MessageType type)
     {
-        return type is MessageType.ToolInventoryRequest or MessageType.ToolInstallRequest;
+        return type is MessageType.ToolInventoryRequest or MessageType.ToolInstallRequest or MessageType.ToolUninstallRequest;
     }
 
     protected override byte[] Dispatch(string clientId, MessageType type, ReadOnlySpan<byte> data)
@@ -56,6 +60,13 @@ public class ToolMessageHandler : MessageHandlerBase
                                     await sendAsync(
                                         ToolProtocolSerializer.SerializeInstallProgress(messageId, progress));
                                 },
+                                async (prompt, ct) =>
+                                {
+                                    if (_requestSecretAsync is null)
+                                        return null;
+
+                                    return await _requestSecretAsync(clientId, prompt, ct);
+                                },
                                 cancellationToken);
 
                             var inventory = await _toolInstallationCoordinator.GetInventoryAsync(cancellationToken);
@@ -71,6 +82,51 @@ public class ToolMessageHandler : MessageHandlerBase
                     }, cancellationToken);
 
                     return ToolProtocolSerializer.SerializeInstallAccepted(messageId, true);
+                }
+
+            case MessageType.ToolUninstallRequest:
+                {
+                    var request = new ToolUninstallRequest(data);
+                    var messageId = request.MessageId;
+                    var toolIds = request.ToolIds.ToArray();
+                    var sendAsync = CurrentSendAsync
+                        ?? throw new InvalidOperationException("CurrentSendAsync is not available.");
+
+                    var cancellationToken = CurrentCancellationToken;
+
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await _toolInstallationCoordinator.UninstallAsync(
+                                toolIds,
+                                async progress =>
+                                {
+                                    await sendAsync(
+                                        ToolProtocolSerializer.SerializeInstallProgress(messageId, progress));
+                                },
+                                async (prompt, ct) =>
+                                {
+                                    if (_requestSecretAsync is null)
+                                        return null;
+
+                                    return await _requestSecretAsync(clientId, prompt, ct);
+                                },
+                                cancellationToken);
+
+                            var inventory = await _toolInstallationCoordinator.GetInventoryAsync(cancellationToken);
+
+                            await sendAsync(
+                                ToolProtocolSerializer.SerializeInventoryResult(messageId, inventory));
+                        }
+                        catch (Exception ex)
+                        {
+                            await sendAsync(
+                                ToolProtocolSerializer.SerializeError(messageId, ex.Message));
+                        }
+                    }, cancellationToken);
+
+                    return ToolProtocolSerializer.SerializeUninstallAccepted(messageId, true);
                 }
 
             default:

--- a/src/CtfDeck.Terminal/Resources/tool-catalog.json
+++ b/src/CtfDeck.Terminal/Resources/tool-catalog.json
@@ -370,6 +370,111 @@
       ]
     },
     {
+      "id": "nmap",
+      "displayName": "Nmap",
+      "category": "PORT_SCANNING",
+      "kind": "binary",
+      "description": "Network mapper and port scanner",
+      "commandTemplate": "nmap -sV {host}",
+      "externalUrl": "https://nmap.org",
+      "checkCommand": "nmap",
+      "checkArguments": "--help",
+      "installers": [
+        {
+          "os": "windows",
+          "arch": "x64",
+          "type": "packageManager",
+          "packageManager": "winget",
+          "packageId": "Insecure.Nmap",
+          "requiresElevation": true
+        },
+        {
+          "os": "linux",
+          "arch": "x64",
+          "type": "packageManager",
+          "packageManager": "apt",
+          "packageId": "nmap",
+          "requiresElevation": true
+        },
+        {
+          "os": "linux",
+          "arch": "x64",
+          "type": "packageManager",
+          "packageManager": "dnf",
+          "packageId": "nmap",
+          "requiresElevation": true
+        },
+        {
+          "os": "linux",
+          "arch": "x64",
+          "type": "packageManager",
+          "packageManager": "pacman",
+          "packageId": "nmap",
+          "requiresElevation": true
+        },
+        {
+          "os": "macos",
+          "arch": "arm64",
+          "type": "packageManager",
+          "packageManager": "brew",
+          "packageId": "nmap"
+        }
+      ]
+    },
+    {
+      "id": "hashcat",
+      "displayName": "Hashcat",
+      "category": "PASSWORD_CRACKING",
+      "kind": "binary",
+      "description": "Advanced password recovery",
+      "commandTemplate": "hashcat --help",
+      "externalUrl": "https://hashcat.net/hashcat/",
+      "checkCommand": "hashcat",
+      "checkArguments": "--help",
+      "installers": [
+        {
+          "os": "windows",
+          "arch": "x64",
+          "type": "archive",
+          "url": "https://hashcat.net/files/hashcat-6.2.6.7z",
+          "archiveType": "7z",
+          "executableName": "hashcat.exe",
+          "executableRelativePath": "hashcat-6.2.6/hashcat.exe"
+        },
+        {
+          "os": "linux",
+          "arch": "x64",
+          "type": "packageManager",
+          "packageManager": "apt",
+          "packageId": "hashcat",
+          "requiresElevation": true
+        },
+        {
+          "os": "linux",
+          "arch": "x64",
+          "type": "packageManager",
+          "packageManager": "dnf",
+          "packageId": "hashcat",
+          "requiresElevation": true
+        },
+        {
+          "os": "linux",
+          "arch": "x64",
+          "type": "packageManager",
+          "packageManager": "pacman",
+          "packageId": "hashcat",
+          "requiresElevation": true
+        },
+        {
+          "os": "macos",
+          "arch": "arm64",
+          "type": "packageManager",
+          "packageManager": "brew",
+          "packageId": "hashcat"
+        }
+      ]
+    },
+    {
       "id": "revshells",
       "displayName": "RevShells",
       "category": "REVERSE_SHELL",

--- a/src/CtfDeck.Terminal/Terminal/Execution/ProcessRunner.cs
+++ b/src/CtfDeck.Terminal/Terminal/Execution/ProcessRunner.cs
@@ -15,6 +15,7 @@ public static class ProcessRunner
         string workingDirectory,
         Func<string, bool, Task> onOutput,
         Func<StreamWriter, Task>? writeStdin = null,
+        Action<StreamWriter>? onStdinReady = null,
         CancellationToken cancellationToken = default)
     {
         using var process = CreateProcess(shell, command, workingDirectory);
@@ -26,17 +27,20 @@ public static class ProcessRunner
         {
             process.Start();
 
-            // If sudoPassword was provided, write it ASAP to stdin
+            // If sudoPassword was provided, write it ASAP to stdin (kept open for EOF signal)
             if (writeStdin != null)
             {
                 try
                 {
                     await writeStdin(process.StandardInput);
                     await process.StandardInput.FlushAsync();
-                    process.StandardInput.Close();
                 }
                 catch { /* ignore */ }
             }
+
+            // Publish stdin to the caller so it can close it on EOF (Ctrl+D) signal
+            try { onStdinReady?.Invoke(process.StandardInput); }
+            catch { /* ignore */ }
 
             using var timeoutCts = new CancellationTokenSource(DefaultTimeout);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);

--- a/src/CtfDeck.Terminal/Terminal/TerminalExecutor.cs
+++ b/src/CtfDeck.Terminal/Terminal/TerminalExecutor.cs
@@ -38,7 +38,8 @@ public sealed class TerminalExecutor : IDisposable
         string command,
         OutputReceivedHandler onOutput,
         CancellationToken cancellationToken = default,
-        string? sudoPassword = null)
+        string? sudoPassword = null,
+        Action<StreamWriter>? onStdinReady = null)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
 
@@ -47,7 +48,7 @@ public sealed class TerminalExecutor : IDisposable
 
         return CommandPreprocessor.IsDirectoryChangeCommand(resolvedCommand)
             ? ExecuteCdAsync(resolvedCommand, onOutput)
-            : ExecuteShellCommandAsync(resolvedCommand, onOutput, cancellationToken, sudoPassword);
+            : ExecuteShellCommandAsync(resolvedCommand, onOutput, cancellationToken, sudoPassword, onStdinReady);
     }
 
     public async Task<CommandResult> ExecuteAsync(
@@ -106,7 +107,8 @@ public sealed class TerminalExecutor : IDisposable
         string command,
         OutputReceivedHandler onOutput,
         CancellationToken cancellationToken,
-        string? sudoPassword)
+        string? sudoPassword,
+        Action<StreamWriter>? onStdinReady)
     {
         try
         {
@@ -129,6 +131,7 @@ public sealed class TerminalExecutor : IDisposable
                     (sudoPassword != null && IsSudo(command))
                         ? (sw => sw.WriteLineAsync(sudoPassword))
                         : null,
+                onStdinReady: onStdinReady,
                 cancellationToken: cancellationToken
             );
         }

--- a/src/CtfDeck.WsServer/WebSocket/BinaryMessageDispatcher.cs
+++ b/src/CtfDeck.WsServer/WebSocket/BinaryMessageDispatcher.cs
@@ -9,6 +9,7 @@ public sealed class BinaryMessageDispatcher
     private readonly Func<ClientContext, WebSocketCommand, Task> _processStreamingAsync;
     private readonly Func<ClientContext, Guid, Task> _handleKillAsync;
     private readonly Func<ClientContext, Guid, CommandSignalKind, Task> _handleSignalAsync;
+    private readonly Func<ClientContext, Guid, string, Task> _handleInputAsync;
     private readonly IReadOnlyList<MessageHandlerBase> _messageHandlers;
     private readonly Action<string> _log;
 
@@ -17,6 +18,7 @@ public sealed class BinaryMessageDispatcher
         Func<ClientContext, WebSocketCommand, Task> processStreamingAsync,
         Func<ClientContext, Guid, Task> handleKillAsync,
         Func<ClientContext, Guid, CommandSignalKind, Task> handleSignalAsync,
+        Func<ClientContext, Guid, string, Task> handleInputAsync,
         IReadOnlyList<MessageHandlerBase> messageHandlers,
         Action<string>? log = null)
     {
@@ -24,6 +26,7 @@ public sealed class BinaryMessageDispatcher
         _processStreamingAsync = processStreamingAsync;
         _handleKillAsync = handleKillAsync;
         _handleSignalAsync = handleSignalAsync;
+        _handleInputAsync = handleInputAsync;
         _messageHandlers = messageHandlers;
         _log = log ?? Console.WriteLine;
     }
@@ -64,6 +67,13 @@ public sealed class BinaryMessageDispatcher
                 {
                     var signalReader = new CommandSignalReader(message.Span);
                     await _handleSignalAsync(ctx, signalReader.CommandId, signalReader.Kind);
+                    break;
+                }
+
+            case MessageType.CommandInput:
+                {
+                    var inputReader = new CommandInputReader(message.Span);
+                    await _handleInputAsync(ctx, inputReader.MessageId, inputReader.Input);
                     break;
                 }
 

--- a/src/CtfDeck.WsServer/WebSocket/BinaryMessageDispatcher.cs
+++ b/src/CtfDeck.WsServer/WebSocket/BinaryMessageDispatcher.cs
@@ -8,6 +8,7 @@ public sealed class BinaryMessageDispatcher
     private readonly Func<ClientContext, WebSocketCommand, Task> _processCdAsync;
     private readonly Func<ClientContext, WebSocketCommand, Task> _processStreamingAsync;
     private readonly Func<ClientContext, Guid, Task> _handleKillAsync;
+    private readonly Func<ClientContext, Guid, CommandSignalKind, Task> _handleSignalAsync;
     private readonly IReadOnlyList<MessageHandlerBase> _messageHandlers;
     private readonly Action<string> _log;
 
@@ -15,12 +16,14 @@ public sealed class BinaryMessageDispatcher
         Func<ClientContext, WebSocketCommand, Task> processCdAsync,
         Func<ClientContext, WebSocketCommand, Task> processStreamingAsync,
         Func<ClientContext, Guid, Task> handleKillAsync,
+        Func<ClientContext, Guid, CommandSignalKind, Task> handleSignalAsync,
         IReadOnlyList<MessageHandlerBase> messageHandlers,
         Action<string>? log = null)
     {
         _processCdAsync = processCdAsync;
         _processStreamingAsync = processStreamingAsync;
         _handleKillAsync = handleKillAsync;
+        _handleSignalAsync = handleSignalAsync;
         _messageHandlers = messageHandlers;
         _log = log ?? Console.WriteLine;
     }
@@ -54,6 +57,13 @@ public sealed class BinaryMessageDispatcher
                 {
                     var killCommandId = new CommandKillReader(message.Span).CommandId;
                     await _handleKillAsync(ctx, killCommandId);
+                    break;
+                }
+
+            case MessageType.CommandSignal:
+                {
+                    var signalReader = new CommandSignalReader(message.Span);
+                    await _handleSignalAsync(ctx, signalReader.CommandId, signalReader.Kind);
                     break;
                 }
 

--- a/src/CtfDeck.WsServer/WebSocket/ClientContext.cs
+++ b/src/CtfDeck.WsServer/WebSocket/ClientContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.IO;
 using System.Net.WebSockets;
 using CtfDeck.Terminal.Terminal;
 
@@ -14,6 +15,7 @@ public sealed class ClientContext : IDisposable
     public ConcurrentDictionary<Guid, CancellationTokenSource> ActiveCommands { get; } = new();
     public ConcurrentDictionary<Guid, TaskCompletionSource<string?>> SudoWaiters { get; } = new();
     public ConcurrentDictionary<Guid, Action> ActiveStdinClosers { get; } = new();
+    public ConcurrentDictionary<Guid, StreamWriter> ActiveStdinWriters { get; } = new();
 
     public ClientContext(string clientId, System.Net.WebSockets.WebSocket webSocket)
     {
@@ -32,6 +34,14 @@ public sealed class ClientContext : IDisposable
         }
 
         ActiveCommands.Clear();
+
+        foreach (var close in ActiveStdinClosers.Values)
+        {
+            try { close(); }
+            catch { /* stream already disposed */ }
+        }
+
+        ActiveStdinClosers.Clear();
 
         foreach (var close in ActiveStdinClosers.Values)
         {

--- a/src/CtfDeck.WsServer/WebSocket/ClientContext.cs
+++ b/src/CtfDeck.WsServer/WebSocket/ClientContext.cs
@@ -13,6 +13,7 @@ public sealed class ClientContext : IDisposable
     public WebSocketSender Sender { get; }
     public ConcurrentDictionary<Guid, CancellationTokenSource> ActiveCommands { get; } = new();
     public ConcurrentDictionary<Guid, TaskCompletionSource<string?>> SudoWaiters { get; } = new();
+    public ConcurrentDictionary<Guid, Action> ActiveStdinClosers { get; } = new();
 
     public ClientContext(string clientId, System.Net.WebSockets.WebSocket webSocket)
     {
@@ -31,6 +32,14 @@ public sealed class ClientContext : IDisposable
         }
 
         ActiveCommands.Clear();
+
+        foreach (var close in ActiveStdinClosers.Values)
+        {
+            try { close(); }
+            catch { /* stream already disposed */ }
+        }
+
+        ActiveStdinClosers.Clear();
         try
         {
             if (WebSocket.State != WebSocketState.Closed && WebSocket.State != WebSocketState.Aborted)

--- a/src/CtfDeck.WsServer/WebSocket/CommandDispatcher.cs
+++ b/src/CtfDeck.WsServer/WebSocket/CommandDispatcher.cs
@@ -83,11 +83,16 @@ public sealed class CommandDispatcher
                 (data, isError) => batcher.EnqueueAsync(data, isError).AsTask(),
                 cts.Token,
                 sudoPassword,
-                sw => ctx.ActiveStdinClosers.TryAdd(command.MessageId, () =>
+                sw =>
                 {
-                    try { sw.Close(); }
-                    catch { /* process may have already exited */ }
-                }));
+                    sw.AutoFlush = true;
+                    ctx.ActiveStdinWriters.TryAdd(command.MessageId, sw);
+                    ctx.ActiveStdinClosers.TryAdd(command.MessageId, () =>
+                    {
+                        try { sw.Close(); }
+                        catch { /* process may have already exited */ }
+                    });
+                });
 
             var accumulatedOutput = await batcher.CompleteAsync(streamResult.ExitCode, executor.CurrentDirectory);
 
@@ -119,6 +124,31 @@ public sealed class CommandDispatcher
         {
             ctx.ActiveCommands.TryRemove(command.MessageId, out _);
             ctx.ActiveStdinClosers.TryRemove(command.MessageId, out _);
+            ctx.ActiveStdinWriters.TryRemove(command.MessageId, out _);
+        }
+    }
+
+    /// <summary>
+    /// Handle CommandInput message — send raw text to a running command's stdin
+    /// </summary>
+    public async Task HandleInputAsync(ClientContext ctx, Guid commandId, string input)
+    {
+        if (ctx.ActiveStdinWriters.TryGetValue(commandId, out var writer))
+        {
+            try
+            {
+                await writer.WriteAsync(input);
+                await writer.FlushAsync();
+                Console.WriteLine($"[INPUT] {commandId} → {input.Length} chars");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[INPUT] Error writing to {commandId}: {ex.Message}");
+            }
+        }
+        else
+        {
+            Console.WriteLine($"[INPUT] {commandId} → not found");
         }
     }
 

--- a/src/CtfDeck.WsServer/WebSocket/CommandDispatcher.cs
+++ b/src/CtfDeck.WsServer/WebSocket/CommandDispatcher.cs
@@ -82,7 +82,12 @@ public sealed class CommandDispatcher
                 resolvedCommand,
                 (data, isError) => batcher.EnqueueAsync(data, isError).AsTask(),
                 cts.Token,
-                sudoPassword);
+                sudoPassword,
+                sw => ctx.ActiveStdinClosers.TryAdd(command.MessageId, () =>
+                {
+                    try { sw.Close(); }
+                    catch { /* process may have already exited */ }
+                }));
 
             var accumulatedOutput = await batcher.CompleteAsync(streamResult.ExitCode, executor.CurrentDirectory);
 
@@ -113,6 +118,7 @@ public sealed class CommandDispatcher
         finally
         {
             ctx.ActiveCommands.TryRemove(command.MessageId, out _);
+            ctx.ActiveStdinClosers.TryRemove(command.MessageId, out _);
         }
     }
 
@@ -140,6 +146,43 @@ public sealed class CommandDispatcher
 
         var killResult = TerminalProtocolSerializer.SerializeCommandKillResult(commandId, success);
         await ctx.Sender.SendAsync(killResult);
+    }
+
+    /// <summary>
+    /// Handle CommandSignal message — Ctrl+C (Interrupt) or Ctrl+D (Eof). Fire-and-forget.
+    /// </summary>
+    public Task HandleSignalAsync(ClientContext ctx, Guid commandId, CommandSignalKind kind)
+    {
+        switch (kind)
+        {
+            case CommandSignalKind.Interrupt:
+                if (ctx.ActiveCommands.TryGetValue(commandId, out var cts))
+                {
+                    try { cts.Cancel(); }
+                    catch (ObjectDisposedException) { /* already finished */ }
+                    Console.WriteLine($"[SIGNAL] {commandId} → interrupt");
+                }
+                else
+                {
+                    Console.WriteLine($"[SIGNAL] {commandId} → interrupt (not found)");
+                }
+                return Task.CompletedTask;
+
+            case CommandSignalKind.Eof:
+                if (ctx.ActiveStdinClosers.TryGetValue(commandId, out var close))
+                {
+                    close();
+                    Console.WriteLine($"[SIGNAL] {commandId} → eof");
+                }
+                else
+                {
+                    Console.WriteLine($"[SIGNAL] {commandId} → eof (not found)");
+                }
+                return Task.CompletedTask;
+
+            default:
+                return Task.CompletedTask;
+        }
     }
 
     /// <summary>

--- a/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
@@ -115,6 +115,7 @@ public class WebSocketServer : IServerHost
             _commandDispatcher.ProcessCdAsync,
             _commandDispatcher.ProcessStreamingAsync,
             _commandDispatcher.HandleKillAsync,
+            _commandDispatcher.HandleSignalAsync,
             _messageHandlers,
             Console.WriteLine);
     }

--- a/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
@@ -77,9 +77,10 @@ public class WebSocketServer : IServerHost
 
         IToolCatalogProvider toolCatalogProvider = new ToolCatalogService();
         IToolPathResolver toolPathResolver = new ToolPathResolver();
-        IToolDetector toolDetector = new ToolDetectionService(toolCatalogProvider, toolPathResolver);
+        IPlatformInfoProvider platformInfoProvider = new PlatformInfoProvider();
+        IToolDetector toolDetector = new ToolDetectionService(toolCatalogProvider, toolPathResolver, platformInfoProvider);
         var archiveExtractor = new ArchiveExtractor();
-        IToolInstaller toolInstaller = new ToolInstallationService(toolPathResolver, archiveExtractor);
+        IToolInstaller toolInstaller = new ToolInstallationService(toolPathResolver, archiveExtractor, platformInfoProvider);
         IToolInstallationCoordinator toolInstallationCoordinator =
             new ToolInstallationCoordinator(toolCatalogProvider, toolDetector, toolInstaller);
         _toolCatalogSnapshotService = new ToolCatalogSnapshotService(toolCatalogProvider, toolDetector);
@@ -108,7 +109,7 @@ public class WebSocketServer : IServerHost
             new WriteUpMessageHandler(writeUpService),
             new MediaMessageHandler(mediaService),
             new ProjectMessageHandler(projectService),
-            new ToolMessageHandler(toolInstallationCoordinator)
+            new ToolMessageHandler(toolInstallationCoordinator, RequestToolSecretAsync)
         ];
 
         _binaryMessageDispatcher = new BinaryMessageDispatcher(
@@ -136,6 +137,36 @@ public class WebSocketServer : IServerHost
             ShellType.PowerShell => ShellKind.Pwsh,
             _ => ShellKind.Any
         };
+    }
+
+    private async Task<string?> RequestToolSecretAsync(string clientId, string prompt, CancellationToken ct)
+    {
+        if (!_clients.TryGetValue(clientId, out var ctx))
+            return null;
+
+        var askId = Guid.NewGuid();
+        var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        ctx.SudoWaiters[askId] = tcs;
+
+        try
+        {
+            var req = TerminalProtocolSerializer.SerializePasswordRequest(askId, prompt);
+            await ctx.Sender.SendAsync(req);
+
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+            await Task.WhenAny(tcs.Task, Task.Delay(Timeout.Infinite, linked.Token));
+
+            return tcs.Task.IsCompleted ? tcs.Task.Result : null;
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            ctx.SudoWaiters.TryRemove(askId, out _);
+        }
     }
 
     public async Task StartAsync()

--- a/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
+++ b/src/CtfDeck.WsServer/WebSocket/WebSocketServer.cs
@@ -116,6 +116,7 @@ public class WebSocketServer : IServerHost
             _commandDispatcher.ProcessStreamingAsync,
             _commandDispatcher.HandleKillAsync,
             _commandDispatcher.HandleSignalAsync,
+            _commandDispatcher.HandleInputAsync,
             _messageHandlers,
             Console.WriteLine);
     }

--- a/tests/CtfDeck.Tests/Terminal/Handlers/ToolMessageHandlerTests.cs
+++ b/tests/CtfDeck.Tests/Terminal/Handlers/ToolMessageHandlerTests.cs
@@ -34,6 +34,15 @@ public class ToolMessageHandlerTests
                 });
             }
         }
+
+        public Task UninstallAsync(
+            IReadOnlyCollection<string> toolIds,
+            Func<ToolInstallProgressDto, Task> progressCallback,
+            Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
     }
 
     private readonly FakeToolInstallationCoordinator _fakeCoordinator;

--- a/tests/CtfDeck.Tests/Terminal/Handlers/ToolMessageHandlerTests.cs
+++ b/tests/CtfDeck.Tests/Terminal/Handlers/ToolMessageHandlerTests.cs
@@ -17,7 +17,11 @@ public class ToolMessageHandlerTests
             return Task.FromResult<IReadOnlyCollection<ToolStatusDto>>(inventory);
         }
 
-        public async Task InstallAsync(IReadOnlyCollection<string> toolIds, Func<ToolInstallProgressDto, Task> onProgress, CancellationToken cancellationToken = default)
+        public async Task InstallAsync(
+            IReadOnlyCollection<string> toolIds,
+            Func<ToolInstallProgressDto, Task> onProgress,
+            Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null,
+            CancellationToken cancellationToken = default)
         {
             foreach (var tool in toolIds)
             {

--- a/tests/CtfDeck.Tests/Tools/ToolServicesTests.cs
+++ b/tests/CtfDeck.Tests/Tools/ToolServicesTests.cs
@@ -135,7 +135,7 @@ public sealed class ArchiveExtractorTests : IDisposable
     public async Task ExtractAsync_Unsupported_ShouldThrow()
     {
         var sut = new ArchiveExtractor();
-        var action = () => sut.ExtractAsync("ignored.bin", Path.Combine(_tempRoot, "bad"), "7z");
+        var action = () => sut.ExtractAsync("ignored.bin", Path.Combine(_tempRoot, "bad"), "rar");
 
         await action.Should().ThrowAsync<NotSupportedException>();
     }
@@ -520,6 +520,11 @@ internal sealed class RecordingInstaller : IToolInstaller
     public Task InstallAsync(ToolDefinition tool, Func<ToolInstallProgressDto, Task> progressCallback, Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null, CancellationToken cancellationToken = default)
     {
         Calls.Add(tool);
+        return Task.CompletedTask;
+    }
+
+    public Task UninstallAsync(ToolDefinition tool, Func<ToolInstallProgressDto, Task> progressCallback, Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null, CancellationToken cancellationToken = default)
+    {
         return Task.CompletedTask;
     }
 }

--- a/tests/CtfDeck.Tests/Tools/ToolServicesTests.cs
+++ b/tests/CtfDeck.Tests/Tools/ToolServicesTests.cs
@@ -162,7 +162,7 @@ public sealed class ToolDetectionServiceTests : IDisposable
     {
         var catalog = new FakeCatalogProvider([]);
         var resolver = new TempPathResolver(_tempRoot);
-        var sut = new ToolDetectionService(catalog, resolver);
+        var sut = new ToolDetectionService(catalog, resolver, new PlatformInfoProvider());
 
         var status = await sut.DetectAsync("missing");
 
@@ -173,7 +173,7 @@ public sealed class ToolDetectionServiceTests : IDisposable
     public async Task DetectAsync_ExternalWebApp_ShouldBeNotInstallable()
     {
         var tool = ToolTestHelpers.MakeExternalTool("search");
-        var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), new TempPathResolver(_tempRoot));
+        var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), new TempPathResolver(_tempRoot), new PlatformInfoProvider());
 
         var status = await sut.DetectAsync(tool.Id);
 
@@ -191,7 +191,7 @@ public sealed class ToolDetectionServiceTests : IDisposable
         {
             Os = os,
             Arch = arch,
-            Type = "download",
+            Type = "archive",
             Url = "http://localhost",
             ArchiveType = "none",
             ExecutableRelativePath = "tool",
@@ -203,7 +203,7 @@ public sealed class ToolDetectionServiceTests : IDisposable
         Directory.CreateDirectory(resolver.GetToolsBinDirectory());
         File.WriteAllText(resolver.GetToolExecutablePath(tool.Id, "tool"), "x");
 
-        var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), resolver);
+        var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), resolver, new PlatformInfoProvider());
         var status = await sut.DetectAsync(tool.Id);
 
         status.Should().NotBeNull();
@@ -228,7 +228,7 @@ public sealed class ToolDetectionServiceTests : IDisposable
         {
             Os = os,
             Arch = arch,
-            Type = "download",
+            Type = "archive",
             Url = "http://localhost",
             ArchiveType = "none",
             ExecutableRelativePath = "path-tool",
@@ -241,7 +241,7 @@ public sealed class ToolDetectionServiceTests : IDisposable
         Environment.SetEnvironmentVariable("PATH", tempPathDir + Path.PathSeparator + previous);
         try
         {
-            var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), new TempPathResolver(_tempRoot));
+            var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), new TempPathResolver(_tempRoot), new PlatformInfoProvider());
             var status = await sut.DetectAsync(tool.Id);
 
             status.Should().NotBeNull();
@@ -259,7 +259,7 @@ public sealed class ToolDetectionServiceTests : IDisposable
     public async Task DetectAsync_NotInstallable_ShouldExplainReason()
     {
         var tool = ToolTestHelpers.MakeBinaryTool("uninstallable", []);
-        var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), new TempPathResolver(_tempRoot));
+        var sut = new ToolDetectionService(new FakeCatalogProvider([tool]), new TempPathResolver(_tempRoot), new PlatformInfoProvider());
 
         var status = await sut.DetectAsync(tool.Id);
 
@@ -356,7 +356,7 @@ public sealed class ToolInstallationServiceTests : IDisposable
     public async Task InstallAsync_NoInstallerForPlatform_ShouldEmitFailedState()
     {
         var resolver = new TempPathResolver(_tempRoot);
-        var sut = new ToolInstallationService(resolver, new ArchiveExtractor());
+        var sut = new ToolInstallationService(resolver, new ArchiveExtractor(), new PlatformInfoProvider());
         var tool = ToolTestHelpers.MakeBinaryTool("no-installer", []);
 
         var progress = new List<ToolInstallProgressDto>();
@@ -382,7 +382,7 @@ public sealed class ToolInstallationServiceTests : IDisposable
         {
             Os = os,
             Arch = arch,
-            Type = "download",
+            Type = "archive",
             Url = server.Url,
             ArchiveType = "none",
             ExecutableRelativePath = exeName,
@@ -390,7 +390,7 @@ public sealed class ToolInstallationServiceTests : IDisposable
             Sha256 = "DEADBEEF"
         }]);
 
-        var sut = new ToolInstallationService(new TempPathResolver(_tempRoot), new ArchiveExtractor());
+        var sut = new ToolInstallationService(new TempPathResolver(_tempRoot), new ArchiveExtractor(), new PlatformInfoProvider());
         var progress = new List<ToolInstallProgressDto>();
         await sut.InstallAsync(tool, p =>
         {
@@ -418,7 +418,7 @@ public sealed class ToolInstallationServiceTests : IDisposable
         {
             Os = os,
             Arch = arch,
-            Type = "download",
+            Type = "archive",
             Url = server.Url,
             ArchiveType = "zip",
             ExecutableRelativePath = relativePath,
@@ -428,7 +428,7 @@ public sealed class ToolInstallationServiceTests : IDisposable
         tool.CheckArguments = OperatingSystem.IsWindows() ? "/?" : "";
 
         var resolver = new TempPathResolver(_tempRoot);
-        var sut = new ToolInstallationService(resolver, new ArchiveExtractor());
+        var sut = new ToolInstallationService(resolver, new ArchiveExtractor(), new PlatformInfoProvider());
         var progress = new List<ToolInstallProgressDto>();
 
         await sut.InstallAsync(tool, p =>
@@ -454,7 +454,7 @@ public sealed class ToolInstallationServiceTests : IDisposable
         {
             Os = os,
             Arch = arch,
-            Type = "download",
+            Type = "archive",
             Url = server.Url,
             ArchiveType = "none",
             ExecutableRelativePath = exeName,
@@ -463,7 +463,7 @@ public sealed class ToolInstallationServiceTests : IDisposable
         tool.CheckArguments = "";
 
         var progress = new List<ToolInstallProgressDto>();
-        var sut = new ToolInstallationService(new TempPathResolver(_tempRoot), new ArchiveExtractor());
+        var sut = new ToolInstallationService(new TempPathResolver(_tempRoot), new ArchiveExtractor(), new PlatformInfoProvider());
         await sut.InstallAsync(tool, p =>
         {
             progress.Add(p);
@@ -517,7 +517,7 @@ internal sealed class RecordingInstaller : IToolInstaller
 {
     public List<ToolDefinition> Calls { get; } = [];
 
-    public Task InstallAsync(ToolDefinition tool, Func<ToolInstallProgressDto, Task> progressCallback, CancellationToken cancellationToken = default)
+    public Task InstallAsync(ToolDefinition tool, Func<ToolInstallProgressDto, Task> progressCallback, Func<string, CancellationToken, Task<string?>>? requestSecretAsync = null, CancellationToken cancellationToken = default)
     {
         Calls.Add(tool);
         return Task.CompletedTask;

--- a/tests/CtfDeck.Tests/WebSocket/BinaryMessageDispatcherTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/BinaryMessageDispatcherTests.cs
@@ -30,6 +30,7 @@ public class BinaryMessageDispatcherTests
                 return Task.CompletedTask;
             },
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         var payload = CreateCommandExecute("cd /tmp", Guid.NewGuid());
@@ -57,6 +58,7 @@ public class BinaryMessageDispatcherTests
                 return Task.CompletedTask;
             },
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         var payload = CreateCommandExecute("echo ok", Guid.NewGuid());
@@ -83,6 +85,7 @@ public class BinaryMessageDispatcherTests
                 actualId = id;
                 return Task.CompletedTask;
             },
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -92,6 +95,41 @@ public class BinaryMessageDispatcherTests
         await dispatcher.DispatchAsync(ctx, writer.ToArray(), CancellationToken.None);
 
         actualId.Should().Be(expectedId);
+    }
+
+    [Theory]
+    [InlineData(CommandSignalKind.Interrupt)]
+    [InlineData(CommandSignalKind.Eof)]
+    public async Task DispatchAsync_CommandSignal_ShouldCallSignalHandler(CommandSignalKind kind)
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal", socket);
+
+        var expectedId = Guid.NewGuid();
+        Guid? actualId = null;
+        CommandSignalKind? actualKind = null;
+
+        var dispatcher = new BinaryMessageDispatcher(
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            (_, id, k) =>
+            {
+                actualId = id;
+                actualKind = k;
+                return Task.CompletedTask;
+            },
+            []);
+
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.CommandSignal);
+        writer.WriteGuid(expectedId);
+        writer.WriteByte((byte)kind);
+
+        await dispatcher.DispatchAsync(ctx, writer.ToArray(), CancellationToken.None);
+
+        actualId.Should().Be(expectedId);
+        actualKind.Should().Be(kind);
     }
 
     [Fact]
@@ -105,6 +143,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -131,6 +170,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -156,6 +196,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             [],
             logs.Add);
 
@@ -176,6 +217,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             [handler],
             logs.Add);
 

--- a/tests/CtfDeck.Tests/WebSocket/BinaryMessageDispatcherTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/BinaryMessageDispatcherTests.cs
@@ -31,6 +31,7 @@ public class BinaryMessageDispatcherTests
             },
             (_, _) => Task.CompletedTask,
             (_, _, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         var payload = CreateCommandExecute("cd /tmp", Guid.NewGuid());
@@ -59,6 +60,7 @@ public class BinaryMessageDispatcherTests
             },
             (_, _) => Task.CompletedTask,
             (_, _, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         var payload = CreateCommandExecute("echo ok", Guid.NewGuid());
@@ -85,6 +87,7 @@ public class BinaryMessageDispatcherTests
                 actualId = id;
                 return Task.CompletedTask;
             },
+            (_, _, _) => Task.CompletedTask,
             (_, _, _) => Task.CompletedTask,
             []);
 
@@ -119,6 +122,7 @@ public class BinaryMessageDispatcherTests
                 actualKind = k;
                 return Task.CompletedTask;
             },
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -130,6 +134,42 @@ public class BinaryMessageDispatcherTests
 
         actualId.Should().Be(expectedId);
         actualKind.Should().Be(kind);
+    }
+    [Fact]
+    public async Task DispatchAsync_CommandInput_ShouldCallInputHandler()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-input", socket);
+
+        var expectedId = Guid.NewGuid();
+        var expectedText = "some text\n";
+        Guid? actualId = null;
+        string? actualText = null;
+
+        var dispatcher = new BinaryMessageDispatcher(
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
+            (_, id, text) =>
+            {
+                actualId = id;
+                actualText = text;
+                return Task.CompletedTask;
+            },
+            []);
+
+        var textBytes = System.Text.Encoding.UTF8.GetBytes(expectedText);
+        using var writer = new PooledBufferWriter();
+        writer.WriteByte((byte)MessageType.CommandInput);
+        writer.WriteGuid(expectedId);
+        writer.WriteInt32(textBytes.Length);
+        writer.WriteBytes(textBytes);
+
+        await dispatcher.DispatchAsync(ctx, writer.ToArray(), CancellationToken.None);
+
+        actualId.Should().Be(expectedId);
+        actualText.Should().Be(expectedText);
     }
 
     [Fact]
@@ -143,6 +183,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             (_, _, _) => Task.CompletedTask,
             []);
 
@@ -171,6 +212,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             []);
 
         using var writer = new PooledBufferWriter();
@@ -197,6 +239,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             [],
             logs.Add);
 
@@ -217,6 +260,7 @@ public class BinaryMessageDispatcherTests
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
             (_, _) => Task.CompletedTask,
+            (_, _, _) => Task.CompletedTask,
             (_, _, _) => Task.CompletedTask,
             [handler],
             logs.Add);

--- a/tests/CtfDeck.Tests/WebSocket/BinaryProtocolTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/BinaryProtocolTests.cs
@@ -321,4 +321,28 @@ public class BinaryProtocolTests
         binaryData.Length.Should().BeGreaterThan(0);
         binaryData[0].Should().Be((byte)MessageType.StreamEnd);
     }
+
+    [Theory]
+    [InlineData(CommandSignalKind.Interrupt)]
+    [InlineData(CommandSignalKind.Eof)]
+    public void CommandSignalReader_ShouldParseWireFormat(CommandSignalKind kind)
+    {
+        // Arrange: [1B type=9][16B commandId][1B signalKind] — total 18 bytes
+        var commandId = Guid.NewGuid();
+
+        using var writer = new PooledBufferWriter(18);
+        writer.WriteByte((byte)MessageType.CommandSignal);
+        writer.WriteGuid(commandId);
+        writer.WriteByte((byte)kind);
+        var payload = writer.ToArray();
+
+        // Act
+        var reader = new CommandSignalReader(payload);
+
+        // Assert
+        payload.Length.Should().Be(18);
+        payload[0].Should().Be((byte)MessageType.CommandSignal);
+        reader.CommandId.Should().Be(commandId);
+        reader.Kind.Should().Be(kind);
+    }
 }

--- a/tests/CtfDeck.Tests/WebSocket/CommandDispatcherTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/CommandDispatcherTests.cs
@@ -1,4 +1,5 @@
 using System.Net.WebSockets;
+using System.Text;
 using CtfDeck.Contracts.Models.Sessions;
 using CtfDeck.Contracts.Transport;
 using CtfDeck.Data.Db;
@@ -143,6 +144,38 @@ public sealed class CommandDispatcherTests : IDisposable
 
         closed.Should().BeTrue();
         socket.SentMessages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleInputAsync_WhenWriterExists_ShouldWriteText()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-input", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+        var commandId = Guid.NewGuid();
+
+        using var ms = new MemoryStream();
+        using var sw = new StreamWriter(ms) { AutoFlush = true };
+        ctx.ActiveStdinWriters[commandId] = sw;
+
+        await dispatcher.HandleInputAsync(ctx, commandId, "hello world\n");
+
+        // ms.Position should be at the end, let's reset to read
+        ms.Position = 0;
+        using var sr = new StreamReader(ms);
+        var written = await sr.ReadToEndAsync();
+        written.Should().Be("hello world\n");
+    }
+
+    [Fact]
+    public async Task HandleInputAsync_WhenWriterMissing_ShouldNotThrow()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-input-missing", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+
+        var act = async () => await dispatcher.HandleInputAsync(ctx, Guid.NewGuid(), "ignored");
+        await act.Should().NotThrowAsync();
     }
 
     [Fact]

--- a/tests/CtfDeck.Tests/WebSocket/CommandDispatcherTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/CommandDispatcherTests.cs
@@ -114,6 +114,54 @@ public sealed class CommandDispatcherTests : IDisposable
     }
 
     [Fact]
+    public async Task HandleSignalAsync_Interrupt_ShouldCancelActiveCommand()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal-int", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+        var commandId = Guid.NewGuid();
+        using var cts = new CancellationTokenSource();
+        ctx.ActiveCommands[commandId] = cts;
+
+        await dispatcher.HandleSignalAsync(ctx, commandId, CommandSignalKind.Interrupt);
+
+        cts.IsCancellationRequested.Should().BeTrue();
+        socket.SentMessages.Should().BeEmpty(); // fire-and-forget, no ack
+    }
+
+    [Fact]
+    public async Task HandleSignalAsync_Eof_ShouldInvokeStdinCloser()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal-eof", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+        var commandId = Guid.NewGuid();
+        var closed = false;
+        ctx.ActiveStdinClosers[commandId] = () => closed = true;
+
+        await dispatcher.HandleSignalAsync(ctx, commandId, CommandSignalKind.Eof);
+
+        closed.Should().BeTrue();
+        socket.SentMessages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleSignalAsync_UnknownCommand_ShouldNotThrow()
+    {
+        var socket = new MockWebSocket();
+        using var ctx = new ClientContext("client-signal-missing", socket);
+        var dispatcher = new CommandDispatcher(_activeSessions, CancellationToken.None);
+
+        var act = async () =>
+        {
+            await dispatcher.HandleSignalAsync(ctx, Guid.NewGuid(), CommandSignalKind.Interrupt);
+            await dispatcher.HandleSignalAsync(ctx, Guid.NewGuid(), CommandSignalKind.Eof);
+        };
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
     public async Task ProcessStreamingAsync_SudoWithoutPassword_ShouldEmitKilledStreamEnd()
     {
         var socket = new MockWebSocket();

--- a/tests/CtfDeck.Tests/WebSocket/WebSocketIntegrationTests.cs
+++ b/tests/CtfDeck.Tests/WebSocket/WebSocketIntegrationTests.cs
@@ -516,14 +516,23 @@ public class WebSocketIntegrationTests : IDisposable
         // Act
         await _server.StopAsync();
 
-        // Wait for client to detect closure
-        try
+        // Drain any buffered server messages (e.g. initial ToolCatalogSnapshot) until the
+        // client observes the close/abort — a single receive is fragile because the first
+        // frame may be the catalog, not the close frame.
+        using var drainCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (!drainCts.IsCancellationRequested &&
+               client.State != WebSocketState.CloseReceived &&
+               client.State != WebSocketState.CloseSent &&
+               client.State != WebSocketState.Closed &&
+               client.State != WebSocketState.Aborted)
         {
-            using var waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-            await ReceiveFullMessageBytesAsync(client, waitCts.Token);
+            try
+            {
+                await ReceiveFullMessageBytesAsync(client, drainCts.Token);
+            }
+            catch (WebSocketException) { break; }
+            catch (OperationCanceledException) { break; }
         }
-        catch (WebSocketException) { }
-        catch (OperationCanceledException) { }
 
         // Assert
         client.State.Should().Match(s => s == WebSocketState.CloseReceived || s == WebSocketState.CloseSent || s == WebSocketState.Closed || s == WebSocketState.Aborted);


### PR DESCRIPTION
Closes #76 
This pull request introduces support for tool uninstallation, enhances installer flexibility, and improves platform-specific handling in the tool management system. Key changes include new uninstall methods and protocol messages, expanded installer definitions to support package managers, and improved detection logic for installable tools based on platform and available package managers.

**Tool Uninstallation Support:**
- Added `UninstallAsync` methods to `IToolInstallationCoordinator` and `IToolInstaller` interfaces and implemented them in the coordinator, enabling tools to be uninstalled via the API. [[1]](diffhunk://#diff-29f90f2ddce5c8e8a4646d0fc9b3406a2da211e8b369f7c3981a333867a2e2e2R12-R18) [[2]](diffhunk://#diff-64f655a878a3b22df2f8aae58335cb31a1e7a23041abbf3ef7644708eb22aa45R10-R16) [[3]](diffhunk://#diff-8298ddcef7b1ce921c655b42669f1cbca7ac7dcf4e1840c54cf5e66482f72e1aL46-R73)
- Introduced uninstall protocol messages and request/response classes, including `ToolUninstallRequest`, `ToolUninstallAccepted`, and related message types. [[1]](diffhunk://#diff-ffea8e1d90595984ae1fe9fd295993a94df839fe0d9d8f347d060993ae1a85efR30-R47) [[2]](diffhunk://#diff-244e8578e9b9f8a9cf3df25db045c1d4dc63034f38d5391ecad1c8101c6a8ba0R14-R16) [[3]](diffhunk://#diff-9efa007c6e8be4d9c16f8c131a25b9262602c231c2759093efa1ccf73657235aR128-R134)
- Updated the message handler to support uninstall requests and propagate secret request callbacks.

**Installer Flexibility and Validation:**
- Expanded `ToolInstaller` and `ToolInstallerDto` to support optional fields for archive and package manager installations, including `PackageManager`, `PackageId`, `InstallArgs`, and `RequiresElevation`. [[1]](diffhunk://#diff-8c92b71937d069fe1cba6846505cd17d1f298f9648364ac5fdd0386f7fc7a237L8-R15) [[2]](diffhunk://#diff-04c9c1d1d2f20f8c27b55379e7a8d60a341488a9ec2fdc5b9f9679b5d359ec0cL8-R15)
- Updated validation logic to distinguish between archive and package manager installers, ensuring required fields are present based on installer type.

**Tool Detection and Platform Handling:**
- Improved tool detection logic to select the best installer based on platform and available package managers, and to provide more informative reasons when a tool is not installable. [[1]](diffhunk://#diff-0ad8b16676ea540e3aa21263364c63ea8830935ee5e402f0f2458923006bba88L60-R68) [[2]](diffhunk://#diff-0ad8b16676ea540e3aa21263364c63ea8830935ee5e402f0f2458923006bba88L74-R78) [[3]](diffhunk://#diff-0ad8b16676ea540e3aa21263364c63ea8830935ee5e402f0f2458923006bba88L111-R188)
- Added `PlatformInfoProvider` to abstract OS and architecture detection, and refactored detection code to use this provider. [[1]](diffhunk://#diff-ded6a7132261ab706caa52bd4c1c58890863af1fbd1095c8bbd7c3c7ffcbba98R1-R25) [[2]](diffhunk://#diff-0ad8b16676ea540e3aa21263364c63ea8830935ee5e402f0f2458923006bba88R11-R20)

**Archive Extraction Enhancements:**
- Added support for extracting `.7z` archives using either `tar` on Windows or the `7z` utility on other platforms. [[1]](diffhunk://#diff-8c6eaec55366bc6b0cc6a0213ae7d7308c73c3c9a910ac6b9b1d8cb8af79b27cR1) [[2]](diffhunk://#diff-8c6eaec55366bc6b0cc6a0213ae7d7308c73c3c9a910ac6b9b1d8cb8af79b27cR31-R69)

**Tool Installation State Tracking:**
- Added a new `Uninstalling` state to the `ToolInstallState` enum for better tracking of tool lifecycle.